### PR TITLE
feat: modernize onboarding and analytics foundation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -26,6 +26,8 @@ const eventsRouter  = safeRequire('./src/routes/events.routes')     || safeRequi
 const summaryRouter = safeRequire('./src/routes/summary.routes')    || safeRequire('./routes/summary.routes');
 const billingRouter = safeRequire('./routes/billing')               || safeRequire('./src/routes/billing');
 const vaultRouter  = safeRequire('./routes/vault')                || safeRequire('./src/routes/vault');
+const integrationsRouter = safeRequire('./routes/integrations')     || safeRequire('./src/routes/integrations');
+const analyticsRouter = safeRequire('./routes/analytics')           || safeRequire('./src/routes/analytics');
 
 // ---- AUTH GATE ----
 const { requireAuthOrHtmlUnauthorized } = safeRequire('./middleware/authGate') || { requireAuthOrHtmlUnauthorized: null };
@@ -79,6 +81,8 @@ mount('/api/summary', summaryRouter, 'summary');
 mount('/api/billing', billingRouter, 'billing');
 mount('/api/ai', aiRouter, 'ai');
 mount('/api/vault', vaultRouter, 'vault');
+mount('/api/integrations', integrationsRouter, 'integrations');
+mount('/api/analytics', analyticsRouter, 'analytics');
 
 
 

--- a/backend/models/Subscription.js
+++ b/backend/models/Subscription.js
@@ -5,9 +5,8 @@ const SubscriptionSchema = new mongoose.Schema(
   {
     userId:  { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true, required: true },
 
-    // Plan stored in DB must match your enum (free/basic/premium).
-    // Your routes should already map UI 'professional' -> 'premium' before saving.
-    plan:    { type: String, enum: ['free','basic','premium'], required: true },
+    // Supported plans align with updated licensing model.
+    plan:    { type: String, enum: ['free','starter','growth','premium'], required: true },
 
     // Store the billing interval so 'yearly' doesn't get lost.
     interval: { type: String, enum: ['monthly','yearly'], default: 'monthly', index: true },

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -7,6 +7,32 @@ function generateUid() {
   return 'u_' + rand.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
 }
 
+const IntegrationSchema = new mongoose.Schema({
+  key:          { type: String, required: true },
+  label:        { type: String, required: true },
+  status:       { type: String, enum: ['not_connected','pending','error','connected'], default: 'not_connected' },
+  lastCheckedAt:{ type: Date, default: null },
+  metadata:     { type: mongoose.Schema.Types.Mixed, default: {} },
+}, { _id: false });
+
+const SalaryNavigatorSchema = new mongoose.Schema({
+  targetSalary:      { type: Number, default: null },
+  currentSalary:     { type: Number, default: null },
+  nextReviewAt:      { type: Date, default: null },
+  contractFileId:    { type: mongoose.Schema.Types.ObjectId, ref: 'VaultFile', default: null },
+  benefits:          { type: mongoose.Schema.Types.Mixed, default: {} },
+  achievements:      { type: [mongoose.Schema.Types.Mixed], default: [] },
+  promotionCriteria: { type: [mongoose.Schema.Types.Mixed], default: [] },
+}, { _id: false });
+
+const WealthPlanSchema = new mongoose.Schema({
+  goals:        { type: [mongoose.Schema.Types.Mixed], default: [] },
+  assets:       { type: [mongoose.Schema.Types.Mixed], default: [] },
+  liabilities:  { type: [mongoose.Schema.Types.Mixed], default: [] },
+  strategy:     { type: mongoose.Schema.Types.Mixed, default: {} },
+  lastComputed: { type: Date, default: null },
+}, { _id: false });
+
 const UserSchema = new mongoose.Schema({
   firstName: { type: String, trim: true, required: true },
   lastName:  { type: String, trim: true, required: true },
@@ -14,16 +40,70 @@ const UserSchema = new mongoose.Schema({
   email:     { type: String, trim: true, unique: true, required: true },
   password:  { type: String, required: true },
 
-  // New: DOB (required)
   dateOfBirth: { type: Date, required: true },
 
-  // Permanent cross-link id
   uid:       { type: String, unique: true, index: true, default: generateUid },
 
-  // Existing optional fields
-  licenseTier:   { type: String, enum: ['free','basic','premium'], default: 'free' },
+  licenseTier: {
+    type: String,
+    enum: ['free', 'starter', 'growth', 'premium'],
+    default: 'free'
+  },
+  roles:      { type: [String], default: ['user'] },
+  country:    { type: String, enum: ['uk', 'us'], default: 'uk' },
+
   eulaAcceptedAt:{ type: Date, default: null },
-  eulaVersion:   { type: String, default: null }
+  eulaVersion:   { type: String, default: null },
+
+  emailVerified: { type: Boolean, default: false },
+  emailVerification: {
+    token:     { type: String, default: null },
+    expiresAt: { type: Date, default: null },
+    sentAt:    { type: Date, default: null }
+  },
+
+  trial: {
+    startedAt: { type: Date, default: null },
+    endsAt:    { type: Date, default: null },
+    coupon:    { type: String, default: null },
+    requiresPaymentMethod: { type: Boolean, default: true }
+  },
+
+  subscription: {
+    tier:         { type: String, default: 'free' },
+    status:       { type: String, enum: ['inactive','trial','active','past_due','canceled'], default: 'inactive' },
+    lastPlanChange:{ type: Date, default: null },
+    renewsAt:     { type: Date, default: null }
+  },
+
+  integrations: { type: [IntegrationSchema], default: [] },
+
+  onboarding: {
+    wizardCompletedAt: { type: Date, default: null },
+    tourCompletedAt:   { type: Date, default: null },
+    goals:             { type: [String], default: [] },
+    lastPromptedAt:    { type: Date, default: null }
+  },
+
+  usageStats: {
+    documentsUploaded:   { type: Number, default: 0 },
+    documentsRequiredMet:{ type: Number, default: 0 },
+    moneySavedEstimate:  { type: Number, default: 0 },
+    hmrcFilingsComplete: { type: Number, default: 0 },
+    minutesActive:       { type: Number, default: 0 }
+  },
+
+  salaryNavigator: { type: SalaryNavigatorSchema, default: () => ({}) },
+  wealthPlan:      { type: WealthPlanSchema, default: () => ({}) },
+
+  preferences: {
+    deltaMode: { type: String, enum: ['absolute','percent'], default: 'absolute' },
+    analyticsRange: {
+      preset: { type: String, default: 'last-quarter' },
+      start:  { type: Date, default: null },
+      end:    { type: Date, default: null }
+    }
+  }
 }, { timestamps: true });
 
 module.exports = mongoose.model('User', UserSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.5.1",
     "morgan": "^1.10.1",
-    "multer": "^1.4.5-lts.2"
+    "multer": "^1.4.5-lts.2",
+    "nodemailer": "^6.9.13"
   }
 }

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -1,0 +1,102 @@
+// backend/routes/analytics.js
+const express = require('express');
+const dayjs = require('dayjs');
+const auth = require('../middleware/auth');
+const User = require('../models/User');
+
+const router = express.Router();
+
+function parseRange(query) {
+  const preset = String(query.preset || '').toLowerCase();
+  const start = query.start ? dayjs(query.start) : null;
+  const end = query.end ? dayjs(query.end) : null;
+
+  const now = dayjs();
+  if (start && end && start.isValid() && end.isValid()) {
+    return {
+      mode: 'custom',
+      start: start.startOf('day').toDate(),
+      end: end.endOf('day').toDate(),
+      label: `${start.format('D MMM YYYY')} – ${end.format('D MMM YYYY')}`
+    };
+  }
+
+  switch (preset) {
+    case 'last-year':
+      return {
+        mode: 'preset',
+        preset: 'last-year',
+        start: now.subtract(1, 'year').startOf('year').toDate(),
+        end: now.subtract(1, 'year').endOf('year').toDate(),
+        label: 'Last tax year'
+      };
+    case 'last-quarter':
+      return {
+        mode: 'preset',
+        preset: 'last-quarter',
+        start: now.subtract(1, 'quarter').startOf('quarter').toDate(),
+        end: now.subtract(1, 'quarter').endOf('quarter').toDate(),
+        label: 'Last quarter'
+      };
+    case 'year-to-date':
+      return {
+        mode: 'preset',
+        preset: 'year-to-date',
+        start: now.startOf('year').toDate(),
+        end: now.toDate(),
+        label: 'Year to date'
+      };
+    default:
+      return {
+        mode: 'preset',
+        preset: 'last-month',
+        start: now.subtract(1, 'month').startOf('month').toDate(),
+        end: now.subtract(1, 'month').endOf('month').toDate(),
+        label: 'Last month'
+      };
+  }
+}
+
+// GET /api/analytics/dashboard
+router.get('/dashboard', auth, async (req, res) => {
+  const user = await User.findById(req.user.id).lean();
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const range = parseRange(req.query);
+  const payload = {
+    range,
+    preferences: user.preferences || {},
+    hasData: false,
+    accounting: {
+      metrics: [],
+      allowances: [],
+      obligations: [],
+      documents: {
+        required: [],
+        helpful: [],
+        progress: user.usageStats?.documentsRequiredMet || 0
+      },
+      comparatives: {
+        mode: (user.preferences?.deltaMode || 'absolute'),
+        values: []
+      }
+    },
+    financialPosture: {
+      netWorth: null,
+      breakdown: [],
+      liquidity: null,
+      trends: [],
+      savingsRate: null
+    },
+    salaryNavigator: user.salaryNavigator || {},
+    wealthPlan: user.wealthPlan || {},
+    aiInsights: [],
+    gating: {
+      tier: user.licenseTier || 'free'
+    }
+  };
+
+  res.json(payload);
+});
+
+module.exports = router;

--- a/backend/routes/integrations.js
+++ b/backend/routes/integrations.js
@@ -1,0 +1,64 @@
+// backend/routes/integrations.js
+const express = require('express');
+const auth = require('../middleware/auth');
+const User = require('../models/User');
+
+const router = express.Router();
+
+const VALID_STATUSES = ['not_connected','pending','error','connected'];
+
+function normaliseKey(key) {
+  return String(key || '').toLowerCase();
+}
+
+function normaliseStatus(status) {
+  const val = normaliseKey(status);
+  return VALID_STATUSES.includes(val) ? val : null;
+}
+
+// GET /api/integrations
+router.get('/', auth, async (req, res) => {
+  const user = await User.findById(req.user.id).lean();
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  res.json({ integrations: user.integrations || [] });
+});
+
+// PUT /api/integrations/:key
+router.put('/:key', auth, async (req, res) => {
+  const { key } = req.params;
+  const status = normaliseStatus(req.body?.status);
+  if (!status) return res.status(400).json({ error: 'Invalid status' });
+
+  const user = await User.findById(req.user.id);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const integKey = normaliseKey(key);
+  const list = Array.isArray(user.integrations) ? [...user.integrations] : [];
+  const idx = list.findIndex((i) => normaliseKey(i.key) === integKey);
+  const payload = {
+    key: integKey,
+    label: req.body?.label || (idx >= 0 ? list[idx].label : key),
+    status,
+    lastCheckedAt: new Date(),
+    metadata: req.body?.metadata || {}
+  };
+  if (idx >= 0) list[idx] = { ...list[idx], ...payload };
+  else list.push(payload);
+
+  user.integrations = list;
+  await user.save();
+  res.json({ integration: payload, integrations: list });
+});
+
+// DELETE /api/integrations/:key
+router.delete('/:key', auth, async (req, res) => {
+  const user = await User.findById(req.user.id);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const integKey = normaliseKey(req.params.key);
+  user.integrations = (user.integrations || []).filter((i) => normaliseKey(i.key) !== integKey);
+  await user.save();
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -1,0 +1,75 @@
+// backend/services/mailer.js
+// Lightweight mail helper that falls back to console logging when SMTP env vars are absent.
+
+const nodemailer = safeRequire('nodemailer');
+
+function safeRequire(mod) {
+  try {
+    return require(mod);
+  } catch (err) {
+    return null;
+  }
+}
+
+const {
+  SMTP_HOST,
+  SMTP_PORT,
+  SMTP_SECURE,
+  SMTP_USER,
+  SMTP_PASS,
+  APP_BASE_URL = 'https://www.phloat.io'
+} = process.env;
+
+let transporter = null;
+if (nodemailer && SMTP_HOST && SMTP_USER && SMTP_PASS) {
+  transporter = nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT || 587),
+    secure: String(SMTP_SECURE || 'false') === 'true',
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASS
+    }
+  });
+}
+
+function renderVerificationEmail({ name, token }) {
+  const verifyUrl = `${APP_BASE_URL.replace(/\/$/, '')}/verify-email.html?token=${encodeURIComponent(token)}`;
+  return {
+    subject: 'Confirm your Phloat.io email',
+    html: `
+      <div style="font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+        <h2>Verify your email</h2>
+        <p>Hi ${name || 'there'},</p>
+        <p>Welcome to Phloat.io. Please confirm your email address to unlock your AI accountant.</p>
+        <p><a href="${verifyUrl}" style="background:#2b59ff;color:#fff;padding:12px 20px;border-radius:6px;text-decoration:none;font-weight:600;">Verify email</a></p>
+        <p>If the button doesn't work, copy and paste this link:</p>
+        <p><a href="${verifyUrl}">${verifyUrl}</a></p>
+        <p style="margin-top:32px;">Thanks,<br/>The Phloat.io team</p>
+      </div>
+    `,
+    text: `Hi ${name || 'there'},\n\nVisit the link below to confirm your Phloat.io account.\n${verifyUrl}\n\nThanks,\nPhloat.io`
+  };
+}
+
+async function sendEmailVerification({ to, name, token }) {
+  if (!token) throw new Error('Verification token missing');
+  const { subject, html, text } = renderVerificationEmail({ name, token });
+
+  if (!transporter) {
+    console.info('[mailer] SMTP not configured. Verification link:', { to, subject, token });
+    return;
+  }
+
+  await transporter.sendMail({
+    to,
+    from: process.env.MAIL_FROM || 'Phloat.io <no-reply@phloat.io>',
+    subject,
+    html,
+    text
+  });
+}
+
+module.exports = {
+  sendEmailVerification
+};

--- a/frontend/components/topbar.html
+++ b/frontend/components/topbar.html
@@ -1,9 +1,23 @@
-<nav class="navbar navbar-light bg-light border-bottom">
-  <div class="container-fluid justify-content-center">
+<nav class="navbar navbar-light bg-light border-bottom py-2">
+  <div class="container-fluid justify-content-between align-items-center">
     <a class="navbar-brand d-flex align-items-center gap-2" href="/home.html">
       <i class="bi bi-calculator"></i>
-      <span>AI Accountant</span>
+      <span class="fw-semibold">Phloat.io</span>
     </a>
+    <div class="d-flex align-items-center gap-3">
+      <div class="d-flex align-items-center gap-2 country-toggle" id="country-toggle" role="group" aria-label="Country selector">
+        <button class="btn btn-sm btn-outline-primary active" data-country="uk" type="button">
+          <span class="me-1">🇬🇧</span>
+          <span>United Kingdom</span>
+        </button>
+        <button class="btn btn-sm btn-outline-secondary disabled" type="button" data-country="us" aria-disabled="true">
+          <span class="me-1">🇺🇸</span>
+          <span>United States</span>
+          <span class="badge text-bg-secondary ms-2">Coming soon</span>
+        </button>
+      </div>
+      <div class="text-muted small" id="topbar-user-meta"></div>
+    </div>
   </div>
 </nav>
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -47,6 +47,18 @@
   
   /* cards */
   .card{background:var(--bg-surface); border:1px solid var(--bd-hairline); box-shadow:var(--shadow)}
+  .card.locked{filter:grayscale(.5); opacity:.6}
+
+  .locked-overlay{
+    position:absolute; inset:0;
+    background:rgba(8,16,32,0.68);
+    color:#fff;
+    display:flex; align-items:center; justify-content:center;
+    text-align:center; padding:2rem;
+  }
+  .locked-overlay__content{max-width:320px;}
+  [data-required-tier]{position:relative;}
+  [data-required-tier] .card{position:relative; overflow:hidden;}
   
   /* buttons */
   .btn,.btn-primary,.btn-secondary{

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -9,30 +9,37 @@
   <div id="sidebar-container"></div>
 
   <main class="container py-4">
-    <h1 class="page-title" data-page-title>Dashboard</h1>
+    <header class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-3">
+      <div>
+        <h1 class="page-title" data-page-title>Intelligence Dashboard</h1>
+        <div class="text-muted small">Welcome, <strong id="greeting-name">—</strong></div>
+      </div>
+      <div class="d-flex flex-column text-end small text-muted">
+        <span id="dash-year">Tax year —</span>
+        <span id="range-current" class="fw-semibold">—</span>
+      </div>
+    </header>
 
-    <!-- Greeting -->
-    <div class="alert alert-light border d-flex justify-content-between align-items-center">
-      <div>Welcome, <strong id="greeting-name">—</strong>.</div>
-      <div class="text-muted small" id="dash-year">Tax year —</div>
-    </div>
-
-    <!-- Global Time Range Picker -->
-    <div class="card shadow-sm mb-3">
+    <section class="card shadow-sm border-0 mb-4">
       <div class="card-body">
-        <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
-          <div class="d-flex align-items-center gap-2">
-            <strong>Time range</strong>
-            <span id="range-current" class="text-muted small">—</span>
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+          <div>
+            <h5 class="card-title m-0">AI accountant suggestions</h5>
+            <p class="text-muted small mb-0">Continuous commentary on your spending, obligations and opportunities.</p>
           </div>
-          <div class="btn-group" role="group" aria-label="Mode">
-            <button id="rng-btn-quick" class="btn btn-sm btn-outline-primary active" type="button">Quick options</button>
-            <button id="rng-btn-custom" class="btn btn-sm btn-outline-primary" type="button">Custom</button>
+          <div class="d-flex flex-wrap gap-2 align-items-center">
+            <div class="btn-group btn-group-sm" role="group" aria-label="Range picker">
+              <button id="rng-btn-quick" class="btn btn-outline-primary active" type="button">Quick</button>
+              <button id="rng-btn-custom" class="btn btn-outline-primary" type="button">Custom</button>
+            </div>
+            <div class="btn-group btn-group-sm" role="group" aria-label="Delta mode">
+              <button class="btn btn-outline-primary" id="delta-absolute" type="button">£ delta</button>
+              <button class="btn btn-outline-primary" id="delta-percent" type="button">% delta</button>
+            </div>
           </div>
         </div>
 
-        <!-- QUICK -->
-        <div id="rng-quick" class="mt-2">
+        <div id="rng-quick" class="mt-3">
           <div class="form-check form-check-inline">
             <input class="form-check-input" type="radio" name="rngQuick" id="rng-last-month" value="last-month">
             <label class="form-check-label" for="rng-last-month">Last month</label>
@@ -43,20 +50,23 @@
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" type="radio" name="rngQuick" id="rng-last-year" value="last-year">
-            <label class="form-check-label" for="rng-last-year">Last year</label>
+            <label class="form-check-label" for="rng-last-year">Last tax year</label>
+          </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="rngQuick" id="rng-year-to-date" value="year-to-date">
+            <label class="form-check-label" for="rng-year-to-date">Year to date</label>
           </div>
           <button class="btn btn-sm btn-primary ms-2" id="rng-apply-quick" type="button">Apply</button>
         </div>
 
-        <!-- CUSTOM -->
-        <div id="rng-custom" class="mt-2" style="display:none;">
+        <div id="rng-custom" class="mt-3" style="display:none;">
           <div class="row g-2 align-items-end">
             <div class="col-auto">
-              <label for="rng-start" class="form-label mb-1">Start</label>
+              <label class="form-label mb-1" for="rng-start">Start</label>
               <input type="date" class="form-control form-control-sm" id="rng-start">
             </div>
             <div class="col-auto">
-              <label for="rng-end" class="form-label mb-1">End</label>
+              <label class="form-label mb-1" for="rng-end">End</label>
               <input type="date" class="form-control form-control-sm" id="rng-end">
             </div>
             <div class="col-auto">
@@ -64,114 +74,131 @@
             </div>
           </div>
         </div>
-      </div>
-    </div>
 
-    <!-- KPIs: Tax band, HMRC position, Income, Spend -->
-<div class="row g-3 mb-3" id="kpi-row">
-  <div class="col-6 col-lg-3">
-    <div class="card shadow-sm h-100">
-      <div class="card-body d-flex flex-column justify-content-center">
-        <div class="text-muted small">Tax band</div>
-        <div class="h4 m-0" id="kpi-tax-band">—</div>
+        <div id="ai-suggestions" class="row g-3 mt-3"></div>
+        <div id="ai-suggestions-empty" class="text-muted small mt-3">Insights will appear here once your integrations are connected.</div>
       </div>
-    </div>
-  </div>
-  <div class="col-6 col-lg-3">
-    <div class="card shadow-sm h-100">
-      <div class="card-body d-flex flex-column justify-content-center">
-        <div class="text-muted small">HMRC position (range)</div>
-        <div class="h4 m-0" id="kpi-tax-pos">—</div>
-        <div class="text-muted small" id="kpi-tax-pos-sub">—</div>
-      </div>
-    </div>
-  </div>
-  <div class="col-6 col-lg-3">
-    <div class="card shadow-sm h-100">
-      <div class="card-body d-flex flex-column justify-content-center">
-        <div class="text-muted small">Income (selected)</div>
-        <div class="h4 m-0" id="kpi-income">£—</div>
-      </div>
-    </div>
-  </div>
-  <div class="col-6 col-lg-3">
-    <div class="card shadow-sm h-100">
-      <div class="card-body d-flex flex-column justify-content-center">
-        <div class="text-muted small">Spend (selected)</div>
-        <div class="h4 m-0" id="kpi-spend">£—</div>
-      </div>
-    </div>
-  </div>
-</div>
+    </section>
 
+    <section class="mb-4">
+      <div class="d-flex flex-wrap align-items-center justify-content-between mb-3">
+        <div>
+          <h2 class="h4 mb-0">Accounting intelligence</h2>
+          <p class="text-muted small mb-0">Advanced HMRC tracking, allowance utilisation and income analytics for the selected window.</p>
+        </div>
+        <span class="badge text-bg-light" id="comparison-label">Comparing to previous period</span>
+      </div>
 
-    <!-- Row 1: Waterfall + EMTR -->
-    <div class="row g-3 mb-3">
-      <div class="col-12 col-lg-7">
-        <div class="card shadow-sm h-100">
-          <div class="card-body">
-            <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5 class="card-title m-0">Take-home Waterfall</h5>
-              <button class="btn btn-sm btn-outline-secondary" id="wf-details">View why</button>
+      <div class="row g-3 mb-3">
+        <div class="col-12 col-md-6 col-xl-3">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <div class="text-muted small">Tax band</div>
+              <div class="h4 m-0" id="kpi-tax-band">—</div>
+              <div class="small text-success" id="kpi-tax-band-delta"></div>
             </div>
-            <canvas id="chart-waterfall" height="140"></canvas>
           </div>
         </div>
-      </div>
-      <div class="col-12 col-lg-5">
-        <div class="card shadow-sm h-100">
-          <div class="card-body">
-            <h5 class="card-title">EMTR (Effective marginal tax rate)</h5>
-            <canvas id="chart-emtr" height="140"></canvas>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Row 2: Gauges + Upcoming Events -->
-    <div class="row g-3 mb-3">
-      <div class="col-12 col-lg-7">
-        <div class="card shadow-sm h-100">
-          <div class="card-body">
-            <h5 class="card-title">Allowance usage</h5>
-            <div id="gauges" class="row g-3"></div>
-          </div>
-        </div>
-      </div>
-
-      <div class="col-12 col-lg-5">
-        <div class="card shadow-sm h-100">
-          <div class="card-body d-flex flex-column">
-            <div class="d-flex justify-content-between align-items-center">
-              <h5 class="card-title m-0">Upcoming events</h5>
+        <div class="col-12 col-md-6 col-xl-3">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <div class="text-muted small">HMRC balance</div>
+              <div class="h4 m-0" id="kpi-tax-pos">—</div>
+              <div class="text-muted small" id="kpi-tax-pos-sub">—</div>
             </div>
-            <div id="events-scroll" class="mt-2" style="max-height: 340px; overflow: auto;">
-              <table class="table table-sm table-hover align-middle mb-0" id="events-table">
-                <thead class="table-light" style="position: sticky; top: 0; z-index: 1;">
-                  <tr><th style="width:110px;">Date</th><th>Event</th><th style="width:36px;"></th></tr>
-                </thead>
-                <tbody id="events-tbody"></tbody>
-              </table>
+          </div>
+        </div>
+        <div class="col-12 col-md-6 col-xl-3">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <div class="text-muted small">Gross income</div>
+              <div class="h4 m-0" id="kpi-income">£—</div>
+              <div class="small text-muted" id="kpi-income-delta"></div>
             </div>
-            <div id="events-empty" class="text-muted small mt-2">No upcoming events yet.</div>
+          </div>
+        </div>
+        <div class="col-12 col-md-6 col-xl-3">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <div class="text-muted small">Total spend</div>
+              <div class="h4 m-0" id="kpi-spend">£—</div>
+              <div class="small text-muted" id="kpi-spend-delta"></div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- Financial Posture -->
-    <section class="mb-3">
-      <div class="d-flex justify-content-between align-items-center mb-2">
-        <h4 class="m-0">Financial Posture</h4>
-        <div class="text-muted small">Summary reflects selected time range</div>
+      <div class="row g-3 mb-3">
+        <div class="col-12 col-lg-7">
+          <div class="card shadow-sm h-100">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <h5 class="card-title m-0">Take-home waterfall</h5>
+                <button class="btn btn-sm btn-outline-secondary" id="wf-details">View drivers</button>
+              </div>
+              <canvas id="chart-waterfall" height="140"></canvas>
+              <div class="text-muted small mt-2" id="waterfall-meta"></div>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-lg-5">
+          <div class="card shadow-sm h-100">
+            <div class="card-body">
+              <h5 class="card-title">Effective marginal tax rate</h5>
+              <canvas id="chart-emtr" height="140"></canvas>
+              <div class="text-muted small mt-2">Understand when additional income becomes less efficient.</div>
+            </div>
+          </div>
+        </div>
       </div>
+
       <div class="row g-3">
+        <div class="col-12 col-lg-7">
+          <div class="card shadow-sm h-100">
+            <div class="card-body">
+              <h5 class="card-title">Allowance utilisation</h5>
+              <div id="gauges" class="row g-3"></div>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-lg-5">
+          <div class="card shadow-sm h-100">
+            <div class="card-body d-flex flex-column">
+              <div class="d-flex justify-content-between align-items-center">
+                <h5 class="card-title m-0">Obligations timeline</h5>
+                <button class="btn btn-sm btn-outline-primary" id="events-sync">Sync calendars</button>
+              </div>
+              <div id="events-scroll" class="mt-2 flex-grow-1" style="max-height: 320px; overflow-y: auto;">
+                <table class="table table-sm table-hover align-middle mb-0" id="events-table">
+                  <thead class="table-light" style="position: sticky; top: 0; z-index: 1;">
+                    <tr><th style="width:110px;">Date</th><th>Event</th><th style="width:36px;"></th></tr>
+                  </thead>
+                  <tbody id="events-tbody"></tbody>
+                </table>
+              </div>
+              <div id="events-empty" class="text-muted small mt-2">No data — set up your integrations to get started.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <div class="d-flex flex-wrap align-items-center justify-content-between mb-3">
+        <div>
+          <h2 class="h4 mb-0">Financial posture</h2>
+          <p class="text-muted small mb-0">Visualise your assets, liabilities and cashflow to understand true financial strength.</p>
+        </div>
+        <button class="btn btn-sm btn-outline-primary" id="open-wealth-lab">Launch wealth lab</button>
+      </div>
+
+      <div class="row g-3 mb-3">
         <div class="col-12 col-lg-6">
           <div class="card shadow-sm h-100">
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-start mb-2">
                 <h5 class="card-title m-0">Net worth snapshot</h5>
-                <div class="text-muted small" id="fp-networth-date">—</div>
+                <span class="badge text-bg-light" id="fp-networth-date">—</span>
               </div>
               <div class="row g-3">
                 <div class="col-7">
@@ -179,16 +206,18 @@
                   <div class="text-muted small mb-2">Assets minus liabilities</div>
                   <ul class="list-unstyled mb-0" id="fp-networth-breakdown"></ul>
                 </div>
-                <div class="col-5"><canvas id="fp-networth-chart" height="160"></canvas></div>
+                <div class="col-5 d-flex align-items-center">
+                  <canvas id="fp-networth-chart" height="160"></canvas>
+                </div>
               </div>
+              <div class="alert alert-light border mt-3 d-none" id="fp-networth-empty">No data — set up your integrations to get started.</div>
             </div>
           </div>
         </div>
-
         <div class="col-12 col-lg-6">
           <div class="card shadow-sm h-100">
             <div class="card-body">
-              <h5 class="card-title">Income & spend (selected)</h5>
+              <h5 class="card-title">Income vs expenditure</h5>
               <div class="row g-3 align-items-center">
                 <div class="col-6">
                   <div class="fw-semibold">Total income</div>
@@ -196,20 +225,23 @@
                   <div class="text-muted small" id="fp-inc-notes">—</div>
                 </div>
                 <div class="col-6">
-                  <div class="fw-semibold">Total spent</div>
+                  <div class="fw-semibold">Total spend</div>
                   <div class="h3 m-0" id="fp-spend-total">£—</div>
                   <div class="text-muted small" id="fp-spend-notes">—</div>
                 </div>
               </div>
               <div class="mt-3"><canvas id="fp-incspend-chart" height="120"></canvas></div>
+              <div class="alert alert-light border mt-3 d-none" id="fp-income-empty">No data — set up your integrations to get started.</div>
             </div>
           </div>
         </div>
+      </div>
 
+      <div class="row g-3">
         <div class="col-12 col-lg-6">
           <div class="card shadow-sm h-100">
             <div class="card-body d-flex flex-column">
-              <h5 class="card-title">Biggest costs (selected)</h5>
+              <h5 class="card-title">Biggest costs</h5>
               <div class="table-responsive">
                 <table class="table table-sm align-middle mb-0">
                   <thead class="table-light"><tr><th>Category</th><th class="text-end" style="width:140px;">Amount</th></tr></thead>
@@ -220,12 +252,11 @@
             </div>
           </div>
         </div>
-
         <div class="col-12 col-lg-6">
           <div class="card shadow-sm h-100">
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-center mb-2">
-                <h5 class="card-title m-0">Investments overview</h5>
+                <h5 class="card-title m-0">Investments</h5>
                 <div class="badge text-bg-success" id="fp-perf-ytd">YTD —%</div>
               </div>
               <div class="row g-3">
@@ -241,7 +272,126 @@
             </div>
           </div>
         </div>
+      </div>
+    </section>
 
+    <section class="mb-4" data-required-tier="premium" id="salary-sense">
+      <div class="card shadow-sm border-0">
+        <div class="card-body">
+          <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+            <div>
+              <h2 class="h4 mb-1">Compensation navigator</h2>
+              <p class="text-muted small mb-0">Upload contracts or map packages to see when to negotiate, benchmark roles and prepare evidence.</p>
+            </div>
+            <button class="btn btn-primary" id="salary-upload-contract">Upload contract</button>
+          </div>
+          <div class="row g-3">
+            <div class="col-12 col-xl-4">
+              <div class="card h-100 shadow-sm border">
+                <div class="card-body">
+                  <div class="text-muted small">Current salary</div>
+                  <div class="display-6" id="salary-current">£—</div>
+                  <div class="text-muted small">Including benefits</div>
+                  <hr>
+                  <div class="text-muted small">Target salary</div>
+                  <div class="h4" id="salary-target">£—</div>
+                  <input type="range" class="form-range" id="salary-target-slider" min="0" max="250000" step="1000">
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-xl-4">
+              <div class="card h-100 shadow-sm border">
+                <div class="card-body">
+                  <h5 class="card-title">Next review</h5>
+                  <div id="salary-next-review" class="display-6">—</div>
+                  <p class="text-muted small">We suggest discussing remuneration when this progress bar reaches 100%.</p>
+                  <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" id="salary-review-progress" style="width:0%">0%</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-xl-4">
+              <div class="card h-100 shadow-sm border">
+                <div class="card-body">
+                  <h5 class="card-title">SMART achievements</h5>
+                  <ul class="list-group list-group-flush" id="salary-achievements"></ul>
+                  <button class="btn btn-sm btn-outline-primary mt-3" id="salary-add-achievement">Add achievement</button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="alert alert-info d-flex align-items-center gap-2 mt-3" id="salary-market-insight">
+            <i class="bi bi-lightbulb"></i>
+            <div>
+              <strong>Market check pending</strong>
+              <div class="small">We scan UK job boards to benchmark comparable roles. Set up integrations to unlock automated salary intelligence.</div>
+            </div>
+          </div>
+          <div class="text-end mt-3">
+            <button class="btn btn-outline-secondary" id="salary-export">Export PDF dossier</button>
+          </div>
+          <div class="locked-overlay d-none" data-tier-lock>
+            <div class="locked-overlay__content">
+              <h3 class="h5 mb-2">Premium feature</h3>
+              <p class="mb-3">Unlock dynamic salary benchmarking, SMART evidence tracking and exportable promotion packs.</p>
+              <a href="/billing.html" class="btn btn-primary">View plans</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-5" data-required-tier="premium" id="wealth-lab">
+      <div class="card shadow-sm border-0">
+        <div class="card-body">
+          <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+            <div>
+              <h2 class="h4 mb-1">Wealth strategy lab</h2>
+              <p class="text-muted small mb-0">Aggregate every asset and liability, then generate an AI-guided roadmap towards your goals.</p>
+            </div>
+            <button class="btn btn-primary" id="wealth-add-goal">Add goal</button>
+          </div>
+          <div class="row g-3">
+            <div class="col-12 col-lg-4">
+              <div class="card h-100 border shadow-sm">
+                <div class="card-body">
+                  <h5 class="card-title">Assets</h5>
+                  <ul class="list-group list-group-flush" id="wealth-assets"></ul>
+                  <button class="btn btn-sm btn-outline-primary mt-3" id="wealth-add-asset">Add asset</button>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-lg-4">
+              <div class="card h-100 border shadow-sm">
+                <div class="card-body">
+                  <h5 class="card-title">Liabilities</h5>
+                  <ul class="list-group list-group-flush" id="wealth-liabilities"></ul>
+                  <button class="btn btn-sm btn-outline-primary mt-3" id="wealth-add-liability">Add liability</button>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-lg-4">
+              <div class="card h-100 border shadow-sm">
+                <div class="card-body">
+                  <h5 class="card-title">Strategy engine</h5>
+                  <div class="text-muted small" id="wealth-strategy">Connect your accounts to generate a strategy that clears liabilities and builds assets.</div>
+                  <div class="mt-3">
+                    <canvas id="wealth-strength-chart" height="160"></canvas>
+                  </div>
+                  <div class="text-muted small mt-2">Financial strength score powered by liabilities vs assets.</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="locked-overlay d-none" data-tier-lock>
+            <div class="locked-overlay__content">
+              <h3 class="h5 mb-2">Premium feature</h3>
+              <p class="mb-3">Automate debt clearance plans, savings schedules and growth strategies with Phloat.io Premium.</p>
+              <a class="btn btn-primary" href="/billing.html">Upgrade plan</a>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
   </main>

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -1,372 +1,574 @@
-// frontend/js/dashboard.js (fixed, preserves existing UI)
+// frontend/js/dashboard.js
 (function () {
-  const RANGE_KEY = 'dashboardRangeV1';
+  const RANGE_KEY = 'dashboardRangeV2';
+  const DELTA_KEY = 'dashboardDeltaModeV1';
+  const tierOrder = { free: 0, starter: 1, growth: 2, premium: 3 };
 
-  init().catch(err => {
-    console.error('Dashboard init failed:', err);
-    softError('Could not load dashboard: ' + (err?.message || err));
+  init().catch((err) => {
+    console.error('Dashboard failed to initialise', err);
+    softError('Unable to load dashboard. Please refresh.');
   });
 
   async function init() {
     const { me } = await Auth.requireAuth();
-    Auth.setBannerTitle('Dashboard');
-    const g = document.getElementById('greeting-name');
-    if (g && me?.firstName) g.textContent = me.firstName;
-
+    Auth.setBannerTitle('Intelligence Dashboard');
+    applyTierLocks(me);
     wireRangePicker();
+    wireDeltaButtons(me);
     await reloadDashboard();
   }
 
-  // ---------------- Range state & UI ----------------
-  function defaultRangeState() { return { mode: 'quick', preset: 'last-month', start: null, end: null }; }
-  function loadRangeState() { try { return JSON.parse(localStorage.getItem(RANGE_KEY) || 'null') || defaultRangeState(); } catch { return defaultRangeState(); } }
-  function saveRangeState(st) { try { localStorage.setItem(RANGE_KEY, JSON.stringify(st)); } catch {} }
+  function applyTierLocks(me) {
+    const tierLevel = tierOrder[me?.licenseTier] ?? 0;
+    document.querySelectorAll('[data-required-tier]').forEach((section) => {
+      const required = tierOrder[section.dataset.requiredTier] ?? Infinity;
+      const overlay = section.querySelector('[data-tier-lock]');
+      const cards = section.querySelectorAll('.card');
+      if (tierLevel < required) {
+        overlay?.classList.remove('d-none');
+        cards.forEach((c) => c.classList.add('locked'));
+      } else {
+        overlay?.classList.add('d-none');
+        cards.forEach((c) => c.classList.remove('locked'));
+      }
+    });
+  }
+
+  function defaultRange() {
+    return { mode: 'preset', preset: 'last-quarter', start: null, end: null };
+  }
+  function loadRange() {
+    try { return JSON.parse(localStorage.getItem(RANGE_KEY) || 'null') || defaultRange(); }
+    catch { return defaultRange(); }
+  }
+  function saveRange(st) {
+    try { localStorage.setItem(RANGE_KEY, JSON.stringify(st)); } catch {}
+  }
+
+  function loadDeltaMode() {
+    return localStorage.getItem(DELTA_KEY) || 'absolute';
+  }
+  function saveDeltaMode(mode) {
+    localStorage.setItem(DELTA_KEY, mode);
+  }
+
+  function wireDeltaButtons(me) {
+    const mode = (me?.preferences?.deltaMode || loadDeltaMode());
+    const btnAbs = byId('delta-absolute');
+    const btnPct = byId('delta-percent');
+    setDeltaActive(mode);
+
+    [btnAbs, btnPct].forEach((btn) => {
+      if (!btn) return;
+      btn.addEventListener('click', async () => {
+        const newMode = btn.id === 'delta-percent' ? 'percent' : 'absolute';
+        setDeltaActive(newMode);
+        saveDeltaMode(newMode);
+        try {
+          await Auth.fetch('/api/user/preferences', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ deltaMode: newMode })
+          });
+        } catch (err) {
+          console.warn('Failed to persist delta mode', err);
+        }
+        await reloadDashboard();
+      });
+    });
+  }
+
+  function setDeltaActive(mode) {
+    document.querySelectorAll('#delta-absolute,#delta-percent').forEach((btn) => {
+      if (!btn) return;
+      const active = (mode === 'percent' ? btn.id === 'delta-percent' : btn.id === 'delta-absolute');
+      btn.classList.toggle('active', active);
+      btn.classList.toggle('btn-primary', active);
+      btn.classList.toggle('btn-outline-primary', !active);
+    });
+  }
 
   function wireRangePicker() {
-    const st = loadRangeState();
-    const btnQuick  = byId('rng-btn-quick');
-    const btnCustom = byId('rng-btn-custom');
-    const paneQuick = byId('rng-quick');
-    const paneCustom= byId('rng-custom');
-
-    if (!btnQuick || !btnCustom || !paneQuick || !paneCustom) return;
+    const st = loadRange();
+    const quickBtn = byId('rng-btn-quick');
+    const customBtn = byId('rng-btn-custom');
+    const quickPane = byId('rng-quick');
+    const customPane = byId('rng-custom');
 
     function setMode(mode) {
       st.mode = mode;
-      btnQuick.classList.toggle('active', mode === 'quick');
-      btnCustom.classList.toggle('active', mode === 'custom');
-      paneQuick.style.display = (mode === 'quick') ? '' : 'none';
-      paneCustom.style.display = (mode === 'custom') ? '' : 'none';
-      saveRangeState(st);
-      updateRangeLabel(st);
+      saveRange(st);
+      quickPane.style.display = mode === 'preset' ? '' : 'none';
+      customPane.style.display = mode === 'custom' ? '' : 'none';
+      quickBtn.classList.toggle('active', mode === 'preset');
+      customBtn.classList.toggle('active', mode === 'custom');
     }
-    btnQuick.addEventListener('click', () => setMode('quick'));
-    btnCustom.addEventListener('click', ()=> setMode('custom'));
 
-    const quickRadios = [ 'rng-last-month', 'rng-last-quarter', 'rng-last-year' ].map(byId).filter(Boolean);
-    const applyQuick  = byId('rng-apply-quick');
-    quickRadios.forEach(r => r.addEventListener('change', () => { st.preset = r.value; saveRangeState(st); }));
-    if (applyQuick) applyQuick.addEventListener('click', async () => { await reloadDashboard(); });
+    quickBtn?.addEventListener('click', () => setMode('preset'));
+    customBtn?.addEventListener('click', () => setMode('custom'));
 
-    const startEl = byId('rng-start'), endEl = byId('rng-end'), applyCustom = byId('rng-apply-custom');
-    if (applyCustom) applyCustom.addEventListener('click', async () => {
-      const s = startEl.value, e = endEl.value;
-      if (!s || !e) return alert('Please select both start and end dates.');
-      if (new Date(s) > new Date(e)) return alert('Start date must be before end date.');
-      st.start = s; st.end = e; saveRangeState(st);
-      await reloadDashboard();
+    document.querySelectorAll('input[name="rngQuick"]').forEach((el) => {
+      el.addEventListener('change', () => {
+        st.preset = el.value;
+        saveRange(st);
+      });
     });
 
-    setMode(st.mode || 'quick');
-    const presetEl = byId(st.preset === 'last-year' ? 'rng-last-year' : (st.preset === 'last-quarter' ? 'rng-last-quarter' : 'rng-last-month'));
+    byId('rng-apply-quick')?.addEventListener('click', () => reloadDashboard());
+    byId('rng-apply-custom')?.addEventListener('click', () => {
+      const start = byId('rng-start').value;
+      const end = byId('rng-end').value;
+      if (!start || !end) return alert('Select a start and end date.');
+      if (new Date(start) > new Date(end)) return alert('Start date must be before end date.');
+      st.start = start;
+      st.end = end;
+      saveRange(st);
+      reloadDashboard();
+    });
+
+    setMode(st.mode || 'preset');
+    const presetEl = byId(`rng-${st.preset || 'last-quarter'}`) || byId('rng-last-quarter');
     if (presetEl) presetEl.checked = true;
-    if (st.start && startEl) startEl.value = st.start;
-    if (st.end && endEl)   endEl.value   = st.end;
-    updateRangeLabel(st);
-  }
-  function updateRangeLabel(st) {
-    const el = byId('range-current'); if (!el) return;
-    if (st.mode === 'quick') {
-      const pretty = st.preset === 'last-year' ? 'Last year' : st.preset === 'last-quarter' ? 'Last quarter' : 'Last month';
-      el.textContent = `Current: ${pretty}`;
-    } else if (st.start && st.end) {
-      el.textContent = `Current: ${new Date(st.start).toLocaleDateString()} – ${new Date(st.end).toLocaleDateString()}`;
-    } else el.textContent = '—';
+    if (st.start) byId('rng-start').value = st.start;
+    if (st.end) byId('rng-end').value = st.end;
   }
 
-  // ---------------- Data fetch & render ----------------
   async function reloadDashboard() {
     setText('dash-year', `Tax year ${safeTaxYearLabel(new Date())}`);
+    const st = loadRange();
+    const params = new URLSearchParams();
+    if (st.mode === 'custom' && st.start && st.end) {
+      params.set('start', st.start);
+      params.set('end', st.end);
+    } else {
+      params.set('preset', st.preset || 'last-quarter');
+    }
+    params.set('t', Date.now());
 
-    const st = loadRangeState();
-    const qs = st.mode === 'quick'
-      ? `preset=${encodeURIComponent(st.preset || 'last-month')}`
-      : (st.start && st.end) ? `start=${encodeURIComponent(st.start)}&end=${encodeURIComponent(st.end)}` : `preset=last-month`;
-
-    let data = {};
+    let data = null;
     try {
-      // IMPORTANT: use Auth.fetch (adds Authorization). API.fetch does not exist in this project.
-      const res = await Auth.fetch(`/api/summary/current-year?${qs}&t=${Date.now()}`, { cache: 'no-store' });
-      if (res.ok) data = await res.json();
-      else throw new Error(`Summary ${res.status}`);
-    } catch (e) {
-      console.warn('Summary API failed:', e);
-      softError('Summary API failed.');
+      const res = await Auth.fetch(`/api/analytics/dashboard?${params.toString()}`, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Analytics ${res.status}`);
+      data = await res.json();
+    } catch (err) {
+      console.error('Analytics load error', err);
+      softError('Unable to load analytics data.');
       return;
     }
 
-    // Charts/tiles
-    try { renderWaterfall('chart-waterfall', data.waterfall || []); } catch (e) { console.error('Waterfall render:', e); }
-    try { renderEMTR('chart-emtr', data.emtr || []); } catch (e) { console.error('EMTR render:', e); }
-    try { renderGauges('gauges', data.gauges || {}); } catch (e) { console.error('Gauges render:', e); }
+    updateRangeLabel(data.range);
+    renderSuggestions(data);
+    renderAccounting(data);
+    renderFinancialPosture(data);
+    renderSalaryNavigator(data);
+    renderWealthLab(data);
+  }
 
-    // KPIs (if their tiles exist in DOM)
-    if (data.kpis) {
-      setText('kpi-tax-band', data.kpis.taxBand || '—');
-      const pos = data.kpis.hmrc || {};
-      if (byId('kpi-tax-pos')) {
-        const net = Number(pos.netForRange || 0);
-        const nice = (n)=>'£'+Number(Math.abs(n)).toLocaleString();
-        byId('kpi-tax-pos').textContent = net > 0 ? `Owe ${nice(net)}` : net < 0 ? `Due ${nice(net)}` : 'Settled';
-        const sub = `Est. tax: £${Number(pos.estTaxForRange||0).toLocaleString()} · Payments: £${Number(pos.paymentsInRange||0).toLocaleString()}`;
-        setText('kpi-tax-pos-sub', sub);
-      }
-      setText('kpi-income', money(data.kpis.incomeTotal));
-      setText('kpi-spend',  money(data.kpis.spendTotal));
+  function updateRangeLabel(range) {
+    const label = range?.label || '—';
+    setText('range-current', label);
+  }
+
+  function renderSuggestions(data) {
+    const wrap = byId('ai-suggestions');
+    const empty = byId('ai-suggestions-empty');
+    if (!wrap) return;
+    wrap.innerHTML = '';
+    const insights = Array.isArray(data.aiInsights) ? data.aiInsights : [];
+    if (!insights.length) {
+      empty?.classList.remove('d-none');
+      return;
+    }
+    empty?.classList.add('d-none');
+    for (const insight of insights) {
+      const col = document.createElement('div');
+      col.className = 'col-12 col-md-6 col-xl-4';
+      col.innerHTML = `
+        <div class="border rounded h-100 p-3 bg-light">
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <i class="bi bi-stars text-primary"></i>
+            <span class="fw-semibold">${escapeHtml(insight.title || 'Insight')}</span>
+          </div>
+          <p class="small mb-2">${escapeHtml(insight.body || 'Connect your accounts to unlock personalised commentary.')}</p>
+          ${insight.action ? `<button class="btn btn-sm btn-outline-primary">${escapeHtml(insight.action)}</button>` : ''}
+        </div>`;
+      wrap.appendChild(col);
+    }
+  }
+
+  function renderAccounting(data) {
+    const metrics = data.accounting?.metrics || [];
+    applyMetric('kpi-tax-band', metrics.find((m) => m.key === 'taxBand'));
+    applyMetric('kpi-tax-pos', metrics.find((m) => m.key === 'hmrcBalance'), { subId: 'kpi-tax-pos-sub' });
+    applyMetric('kpi-income', metrics.find((m) => m.key === 'income'), { deltaId: 'kpi-income-delta' });
+    applyMetric('kpi-spend', metrics.find((m) => m.key === 'spend'), { deltaId: 'kpi-spend-delta' });
+    setText('comparison-label', data.accounting?.comparatives?.label || 'Comparing to previous period');
+
+    renderWaterfall('chart-waterfall', data.accounting?.waterfall || []);
+    renderEMTR('chart-emtr', data.accounting?.emtr || []);
+    renderGauges('gauges', data.accounting?.allowances || {});
+
+    const defaults = defaultUkEvents2025_26();
+    const userEvents = loadUserEvents();
+    renderEventsTable(defaults, userEvents, data.hasData);
+  }
+
+  function applyMetric(id, metric, opts = {}) {
+    const el = byId(id);
+    if (!el) return;
+    if (!metric) {
+      el.textContent = '—';
+      if (opts.subId) setText(opts.subId, 'No data — set up your integrations to get started.');
+      if (opts.deltaId) setText(opts.deltaId, '');
+      return;
+    }
+    if (metric.format === 'currency') el.textContent = money(metric.value);
+    else el.textContent = metric.value ?? '—';
+
+    if (opts.subId) setText(opts.subId, metric.subLabel || '');
+    if (opts.deltaId) setText(opts.deltaId, formatDelta(metric.delta, metric.deltaMode));
+    if (opts.noteId) setText(opts.noteId, metric.note || '');
+    if (opts.subtleId) setText(opts.subtleId, metric.subtle || '');
+  }
+
+  function formatDelta(delta, mode) {
+    if (delta == null) return '';
+    const positive = delta > 0;
+    const symbol = positive ? '▲' : delta < 0 ? '▼' : '•';
+    if (mode === 'percent') {
+      return `${symbol} ${Math.abs(delta).toFixed(1)}%`;
+    }
+    return `${symbol} £${Math.abs(delta).toLocaleString()}`;
+  }
+
+  function renderFinancialPosture(data) {
+    const fp = data.financialPosture || {};
+    setText('fp-networth-date', fp.asOf || '—');
+    setText('fp-networth-total', money(fp.netWorth?.total));
+    const breakdown = Array.isArray(fp.breakdown) ? fp.breakdown : [];
+    const list = byId('fp-networth-breakdown');
+    if (list) {
+      list.innerHTML = '';
+      breakdown.forEach((row) => {
+        const li = document.createElement('li');
+        li.innerHTML = `<span>${escapeHtml(row.label || '')}</span><span class="float-end fw-semibold">${money(row.value)}</span>`;
+        list.appendChild(li);
+      });
+    }
+    toggleEmpty('fp-networth-empty', !breakdown.length);
+
+    setText('fp-inc-total', money(fp.income?.total));
+    setText('fp-inc-notes', fp.income?.note || '');
+    setText('fp-spend-total', money(fp.spend?.total));
+    setText('fp-spend-notes', fp.spend?.note || '');
+    toggleEmpty('fp-income-empty', !Array.isArray(fp.income?.series) || !fp.income.series.length);
+
+    renderDonut('fp-networth-chart', breakdown.map((b) => b.value), breakdown.map((b) => b.label));
+    renderBar('fp-incspend-chart', (fp.income?.series || []).map((d) => d.label), (fp.income?.series || []).map((d) => d.value));
+    renderDonut('fp-allocation-chart', (fp.investments?.allocation || []).map((a) => a.value), (fp.investments?.allocation || []).map((a) => a.label));
+    renderLine('fp-portfolio-line', (fp.investments?.history || []).map((h) => h.label), (fp.investments?.history || []).map((h) => h.value));
+
+    const topCostsBody = byId('fp-top-costs-body');
+    if (topCostsBody) {
+      topCostsBody.innerHTML = '';
+      (data.financialPosture?.topCosts || []).forEach((item) => {
+        const ch = Number(item.change || 0);
+        const cls = ch > 0 ? 'text-danger' : ch < 0 ? 'text-success' : 'text-muted';
+        const arrow = ch > 0 ? '▲' : ch < 0 ? '▼' : '•';
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${escapeHtml(item.label || '')}</td>
+          <td class="text-end">${money(item.value)}</td>
+          <td class="text-end ${cls}"><span class="fw-semibold">${arrow} ${Math.abs(ch)}%</span></td>`;
+        topCostsBody.appendChild(tr);
+      });
     }
 
-    // Events
-    try {
-      const defaults = defaultUkEvents2025_26();
-      const userEvents = loadUserEvents();
-      renderEventsTable(defaults, userEvents);
-    } catch (e) { console.error('Events render:', e); }
-
-    // Financial Posture
-    try {
-      if (data.financialPosture) renderFinancialPosture(data.financialPosture, data.trends);
-    } catch (e) { console.error('Financial Posture render:', e); }
-
-    updateRangeLabel(st);
+    setText('fp-perf-ytd', fp.investments?.ytd != null ? `YTD ${Number(fp.investments.ytd).toFixed(1)}%` : 'YTD —%');
   }
 
-  // ---------------- Charts ----------------
-  function themeColors(n) {
-    const root = getComputedStyle(document.documentElement);
-    const list = ['--chart-1','--chart-2','--chart-3','--chart-4','--chart-5','--chart-6','--chart-7','--chart-8']
-      .map(v => root.getPropertyValue(v).trim()).filter(Boolean);
-    const fallback = ['#4a78ff','#60c8ff','#7dd3a8','#f5a524','#ef4d72','#8b5cf6','#f59e0b','#10b981'];
-    const base = list.length ? list : fallback;
-    const out = [];
-    for (let i=0; i<n; i++) out.push(base[i % base.length]);
-    return out;
+  function renderSalaryNavigator(data) {
+    const nav = data.salaryNavigator || {};
+    setText('salary-current', money(nav.currentSalary));
+    setText('salary-target', money(nav.targetSalary));
+    const slider = byId('salary-target-slider');
+    if (slider) {
+      slider.value = Math.min(Math.max(Number(nav.targetSalary || nav.currentSalary || 0), slider.min), slider.max);
+      slider.addEventListener('change', () => {
+        const newVal = Number(slider.value);
+        setText('salary-target', money(newVal));
+        const alert = document.createElement('div');
+        alert.className = 'alert alert-info mt-2';
+        alert.textContent = 'Save pending — connect your HR integration to store this target automatically.';
+        slider.closest('.card-body')?.appendChild(alert);
+      }, { once: true });
+    }
+
+    setText('salary-next-review', nav.nextReviewAt ? new Date(nav.nextReviewAt).toLocaleDateString() : 'Set review date');
+    const pct = Math.min(100, Math.max(0, Number(nav.progress || 0)));
+    const bar = byId('salary-review-progress');
+    if (bar) {
+      bar.style.width = `${pct}%`;
+      bar.textContent = `${pct}%`;
+    }
+
+    const list = byId('salary-achievements');
+    if (list) {
+      list.innerHTML = '';
+      (nav.achievements || []).forEach((ach) => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.innerHTML = `<div class="fw-semibold">${escapeHtml(ach.title || 'Achievement')}</div><div class="small text-muted">${escapeHtml(ach.detail || '')}</div>`;
+        list.appendChild(li);
+      });
+      if (!nav.achievements?.length) {
+        list.innerHTML = '<li class="list-group-item text-muted">Add SMART objectives to build your promotion dossier.</li>';
+      }
+    }
   }
 
-  // ---- Waterfall (positive-only bars, themed colors)
+  function renderWealthLab(data) {
+    const wealth = data.wealthPlan || {};
+    renderList('wealth-assets', wealth.assets, 'Add your assets to calculate net worth.');
+    renderList('wealth-liabilities', wealth.liabilities, 'Record liabilities to build a payoff plan.');
+    const ctxValues = [wealth.summary?.strength || 0, 100 - (wealth.summary?.strength || 0)];
+    renderDonut('wealth-strength-chart', ctxValues, ['Strength', 'Headroom']);
+    setText('wealth-strategy', wealth.strategy?.summary || 'Connect your banks and upload statements to generate a tailored strategy.');
+  }
+
+  function renderList(id, items, emptyMsg) {
+    const el = byId(id);
+    if (!el) return;
+    el.innerHTML = '';
+    if (!Array.isArray(items) || !items.length) {
+      el.innerHTML = `<li class="list-group-item text-muted">${escapeHtml(emptyMsg)}</li>`;
+      return;
+    }
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item d-flex justify-content-between align-items-start gap-2';
+      li.innerHTML = `
+        <div>
+          <div class="fw-semibold">${escapeHtml(item.label || 'Item')}</div>
+          <div class="small text-muted">${escapeHtml(item.note || '')}</div>
+        </div>
+        <div class="fw-semibold">${money(item.value)}</div>`;
+      el.appendChild(li);
+    });
+  }
+
+  // ----- Charts -----
   function renderWaterfall(canvasId, steps) {
-    const el = document.getElementById(canvasId);
-    if (!el || !Array.isArray(steps) || steps.length === 0 || !window.Chart) return;
+    const el = byId(canvasId);
+    if (!el || !window.Chart) return;
     if (el._chart) el._chart.destroy();
-
-    const labels = steps.map(s => s.label);
-    const values = steps.map(s => Math.max(0, Number(s.amount || 0))); // force positive
-    const colors = themeColors(values.length);
-
+    if (!Array.isArray(steps) || !steps.length) {
+      el.getContext('2d')?.clearRect(0, 0, el.width, el.height);
+      return;
+    }
+    const labels = steps.map((s) => s.label);
+    const values = steps.map((s) => Math.max(0, Number(s.amount || 0)));
     el._chart = new Chart(el, {
       type: 'bar',
-      data: { labels, datasets: [{ data: values, backgroundColor: colors, borderWidth: 0 }] },
+      data: { labels, datasets: [{ data: values, backgroundColor: themeColors(values.length), borderWidth: 0 }] },
       options: {
         responsive: true,
-        plugins: {
-          legend: { display: false },
-          tooltip: { callbacks: { label: (c) => `£${Number(c.parsed.y || 0).toLocaleString()}` } }
-        },
+        plugins: { legend: { display: false }, tooltip: { callbacks: { label: (c) => money(c.parsed.y) } } },
         scales: {
           x: { stacked: false },
-          y: { beginAtZero: true, ticks: { callback: (v) => '£' + Number(v).toLocaleString() } }
+          y: { beginAtZero: true, ticks: { callback: (v) => money(v) } }
         }
       }
     });
   }
 
   function renderEMTR(canvasId, points) {
-    const el = document.getElementById(canvasId);
-    if (!el || !Array.isArray(points) || points.length === 0 || !window.Chart) return;
+    const el = byId(canvasId);
+    if (!el || !window.Chart) return;
     if (el._chart) el._chart.destroy();
-
-    const xs = points.map(p => p.income || 0);
-    const ys = points.map(p => (p.rate || 0) * 100);
-
+    if (!Array.isArray(points) || !points.length) {
+      el.getContext('2d')?.clearRect(0, 0, el.width, el.height);
+      return;
+    }
+    const xs = points.map((p) => p.income || 0);
+    const ys = points.map((p) => (p.rate || 0) * 100);
     el._chart = new Chart(el, {
       type: 'line',
       data: { labels: xs, datasets: [{ data: ys, borderWidth: 2, fill: false, tension: 0.2 }] },
       options: {
         responsive: true,
-        plugins: {
-          legend: { display: false },
-          tooltip: { callbacks: { label: (c) => `${c.parsed.y.toFixed(1)}% EMTR` } }
-        },
+        plugins: { legend: { display: false }, tooltip: { callbacks: { label: (c) => `${c.parsed.y.toFixed(1)}%` } } },
         scales: {
-          x: { title: { display: true, text: 'Annualised income (£)' }, ticks: { callback: (v, i) => '£' + Number(xs[i]).toLocaleString() } },
+          x: { title: { display: true, text: 'Annualised income (£)' }, ticks: { callback: (v, i) => money(xs[i]) } },
           y: { title: { display: true, text: 'Rate (%)' }, min: 0, max: 70 }
         }
       }
     });
   }
 
-  // ---- Gauges
   function renderGauges(containerId, gauges) {
-    const c = document.getElementById(containerId);
-    if (!c) return; c.innerHTML = '';
-    const entries = [
-      ['Personal allowance', gauges.personalAllowance],
-      ['Dividend allowance', gauges.dividendAllowance],
-      ['CGT allowance',      gauges.cgtAllowance],
-      ['Pension annual',     gauges.pensionAnnual],
-      ['ISA',                gauges.isa]
-    ];
-    for (const [label, g] of entries) {
-      const used = Math.max(0, Number(g?.used || 0));
-      const total = Math.max(1, Number(g?.total || 1));
-      const pct = Math.min(100, Math.round((used / total) * 100));
-      const pretty = (n) => '£' + Number(n).toLocaleString();
+    const container = byId(containerId);
+    if (!container) return;
+    container.innerHTML = '';
+    const entries = Array.isArray(gauges) ? gauges : [];
+    if (!entries.length) {
+      container.innerHTML = '<div class="col-12 text-muted small">No data — set up your integrations to get started.</div>';
+      return;
+    }
+    entries.forEach((g) => {
+      const pct = Math.min(100, Math.round((Number(g.used || 0) / Math.max(1, Number(g.total || 1))) * 100));
+      const pretty = (n) => money(n).replace('£-', '-£');
       const tile = document.createElement('div');
       tile.className = 'col-12 col-md-6';
       tile.innerHTML = `
         <div class="border rounded p-3 h-100">
           <div class="d-flex justify-content-between align-items-center mb-1">
-            <div class="fw-semibold">${label}</div>
-            <div class="text-muted small">${pretty(used)} / ${pretty(total)}</div>
+            <div class="fw-semibold">${escapeHtml(g.label || 'Allowance')}</div>
+            <div class="text-muted small">${pretty(g.used)} / ${pretty(g.total)}</div>
           </div>
           <div class="progress" role="progressbar" aria-valuenow="${pct}" aria-valuemin="0" aria-valuemax="100">
             <div class="progress-bar" style="width:${pct}%"></div>
           </div>
         </div>`;
-      c.appendChild(tile);
-    }
+      container.appendChild(tile);
+    });
   }
 
-  // ---- Events
+  function renderDonut(id, data, labels) {
+    const el = byId(id);
+    if (!el || !window.Chart) return;
+    if (el._chart) el._chart.destroy();
+    if (!Array.isArray(data) || !data.length) {
+      el.getContext('2d')?.clearRect(0, 0, el.width, el.height);
+      return;
+    }
+    el._chart = new Chart(el, {
+      type: 'doughnut',
+      data: { labels, datasets: [{ data, backgroundColor: themeColors(data.length) }] },
+      options: { plugins: { legend: { display: true, position: 'bottom' } }, cutout: '60%' }
+    });
+  }
+
+  function renderBar(id, labels, values) {
+    const el = byId(id);
+    if (!el || !window.Chart) return;
+    if (el._chart) el._chart.destroy();
+    if (!values.length) {
+      el.getContext('2d')?.clearRect(0, 0, el.width, el.height);
+      return;
+    }
+    el._chart = new Chart(el, {
+      type: 'bar',
+      data: { labels, datasets: [{ data: values, backgroundColor: themeColors(values.length) }] },
+      options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { callback: (v) => money(v) } } } }
+    });
+  }
+
+  function renderLine(id, labels, values) {
+    const el = byId(id);
+    if (!el || !window.Chart) return;
+    if (el._chart) el._chart.destroy();
+    if (!values.length) {
+      el.getContext('2d')?.clearRect(0, 0, el.width, el.height);
+      return;
+    }
+    el._chart = new Chart(el, {
+      type: 'line',
+      data: { labels, datasets: [{ data: values, borderWidth: 2, fill: false, tension: 0.2 }] },
+      options: { plugins: { legend: { display: false } }, scales: { y: { ticks: { callback: (v) => money(v) } } } }
+    });
+  }
+
+  // ----- Events -----
   const USER_EVENTS_KEY = 'userEvents';
-  function loadUserEvents(){ try { return JSON.parse(localStorage.getItem(USER_EVENTS_KEY) || '[]'); } catch { return []; } }
-  function renderEventsTable(defaults, userEvents) {
-    const tbody = byId('events-tbody'), empty = byId('events-empty');
-    if (!tbody) return; tbody.innerHTML = '';
-    const now = new Date();
-    const combined = [...defaults.map(d => ({...d, kind:'default'})), ...userEvents.map(u => ({...u, kind:'user'}))]
-      .filter(ev => !ev.date || new Date(ev.date) >= new Date(now.getFullYear(), now.getMonth(), now.getDate()))
-      .sort((a,b)=> new Date(a.date) - new Date(b.date));
-    if (combined.length === 0) { if (empty) empty.style.display = ''; return; }
-    if (empty) empty.style.display = 'none';
-    for (const ev of combined) {
+  function loadUserEvents() {
+    try { return JSON.parse(localStorage.getItem(USER_EVENTS_KEY) || '[]'); }
+    catch { return []; }
+  }
+  function renderEventsTable(defaults, userEvents, hasData) {
+    const tbody = byId('events-tbody');
+    const empty = byId('events-empty');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    const combined = [...defaults.map((d) => ({ ...d, kind: 'default' })), ...userEvents.map((u) => ({ ...u, kind: 'user' }))]
+      .filter((ev) => !ev.date || new Date(ev.date) >= new Date())
+      .sort((a, b) => new Date(a.date) - new Date(b.date));
+
+    if (!combined.length) {
+      empty?.classList.remove('d-none');
+      empty.textContent = hasData ? 'No upcoming events yet.' : 'No data — set up your integrations to get started.';
+      return;
+    }
+    empty?.classList.add('d-none');
+
+    combined.forEach((ev) => {
       const tr = document.createElement('tr');
-      const d = ev.date ? new Date(ev.date) : null;
-      const dateStr = d ? d.toLocaleDateString() : '—';
+      const date = ev.date ? new Date(ev.date) : null;
       tr.className = ev.kind === 'user' ? 'event-user' : 'event-default';
       tr.innerHTML = `
-        <td class="text-nowrap">${dateStr}</td>
+        <td class="text-nowrap">${date ? date.toLocaleDateString() : '—'}</td>
         <td><span class="event-title" title="${escapeHtml(ev.description || '')}">${escapeHtml(ev.title || 'Event')}</span></td>
-        <td class="text-end">${ev.kind==='user'?`<button class="btn btn-sm btn-link text-danger p-0" title="Delete"><i class="bi bi-x-circle"></i></button>`:''}</td>`;
-      if (ev.kind === 'user') tr.querySelector('button')?.addEventListener('click', () => {
-        const next = loadUserEvents().filter(x => x.id !== ev.id);
-        localStorage.setItem(USER_EVENTS_KEY, JSON.stringify(next));
-        renderEventsTable(defaults, next);
-      });
+        <td class="text-end">${ev.kind === 'user' ? '<button class="btn btn-sm btn-link text-danger p-0" title="Delete"><i class="bi bi-x-circle"></i></button>' : ''}</td>`;
+      if (ev.kind === 'user') {
+        tr.querySelector('button')?.addEventListener('click', () => {
+          const next = loadUserEvents().filter((x) => x.id !== ev.id);
+          localStorage.setItem(USER_EVENTS_KEY, JSON.stringify(next));
+          renderEventsTable(defaults, next, hasData);
+        });
+      }
       tbody.appendChild(tr);
-    }
+    });
   }
-  function defaultUkEvents2025_26(){
+
+  function defaultUkEvents2025_26() {
     return [
-      { title: 'Second payment on account (2024/25) due', date: '2025-07-31', description: 'HMRC SA 2nd payment on account (if applicable).' },
-      { title: 'Register for Self Assessment (new filers)', date: '2025-10-05', description: 'Deadline to register if you need to file for 2024/25.' },
-      { title: 'Paper tax return deadline (2024/25)', date: '2025-10-31', description: 'Submit paper SA return by midnight.' },
-      { title: 'PAYE coding via online SA (if applicable)', date: '2025-12-30', description: 'Deadline to have tax collected via PAYE through return.' },
-      { title: 'Online SA return + balancing payment (2024/25)', date: '2026-01-31', description: 'Online filing; balancing payment and 1st POA (2025/26).' },
-      { title: 'End of tax year (2025/26)', date: '2026-04-05', description: 'Last day to use ISA & pension allowances and CGT AE for 2025/26.' },
-      { title: 'New tax year (2026/27) starts', date: '2026-04-06', description: 'Reset allowances; update planning.' }
+      { title: 'Second payment on account due', date: '2025-07-31', description: 'HMRC self assessment payment on account.' },
+      { title: 'Register for self assessment', date: '2025-10-05', description: 'Deadline to register if you need to file a return.' },
+      { title: 'Paper tax return deadline', date: '2025-10-31', description: 'Submit paper tax return for 2024/25.' },
+      { title: 'PAYE coding deadline', date: '2025-12-30', description: 'Have tax collected via PAYE through your return.' },
+      { title: 'Online SA & payment deadline', date: '2026-01-31', description: 'Online filing and balancing payment deadline.' },
+      { title: 'Tax year ends', date: '2026-04-05', description: 'Last day to use ISA, pension allowances, CGT AE.' },
+      { title: 'New tax year begins', date: '2026-04-06', description: 'Reset allowances and begin planning.' }
     ];
   }
 
-  // ---- Financial Posture render
-  function renderFinancialPosture(fp, trends) {
-    setText('fp-networth-date', fp.asOf);
-    setText('fp-networth-total', money(fp.netWorth.total));
-    const ul = byId('fp-networth-breakdown');
-    if (ul) {
-      ul.innerHTML = '';
-      for (const row of [
-        ['Savings', fp.netWorth.savings],
-        ['Investments', fp.netWorth.investments],
-        ['Assets', fp.netWorth.assets],
-        ['Credit (owed)', -Math.abs(fp.netWorth.credit)],
-        ['Loans (owed)', -Math.abs(fp.netWorth.loans)]
-      ]) {
-        const li = document.createElement('li');
-        li.innerHTML = `<span>${row[0]}</span> <span class="float-end fw-semibold">${money(row[1])}</span>`;
-        ul.appendChild(li);
-      }
-    }
-    // Networth doughnut
-    if (window.Chart) {
-      const nw = byId('fp-networth-chart');
-      if (nw) { if (nw._chart) nw._chart.destroy(); nw._chart = new Chart(nw, {
-        type: 'doughnut',
-        data: {
-          labels: ['Savings','Investments','Assets','Credit','Loans'],
-          datasets: [{ data: [
-            fp.netWorth.savings,
-            fp.netWorth.investments,
-            fp.netWorth.assets,
-            Math.abs(fp.netWorth.credit),
-            Math.abs(fp.netWorth.loans)
-          ]}]
-        },
-        options: { plugins: { legend: { display: true, position: 'bottom' } }, cutout: '60%' }
-      });}
-    }
-    // Inc/Spend KPIs + bar
-    setText('fp-inc-total', money(fp.lastMonth.incomeTotal));
-    setText('fp-spend-total', money(fp.lastMonth.spendTotal));
-    setText('fp-spend-notes', fp.lastMonth.spendNote || '');
-    if (window.Chart) {
-      const isEl = byId('fp-incspend-chart');
-      if (isEl) { if (isEl._chart) isEl._chart.destroy(); isEl._chart = new Chart(isEl, {
-        type: 'bar',
-        data: { labels: fp.lastMonth.categories.map(c => c.name), datasets: [{ data: fp.lastMonth.categories.map(c => c.amount) }] },
-        options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { callback: v => '£'+Number(v).toLocaleString() } } } }
-      });}
-    }
-    // Allocation donut
-    if (window.Chart) {
-      const alloc = byId('fp-allocation-chart');
-      if (alloc && fp.investments && Array.isArray(fp.investments.allocation)) {
-        if (alloc._chart) alloc._chart.destroy();
-        alloc._chart = new Chart(alloc, {
-          type: 'doughnut',
-          data: { labels: fp.investments.allocation.map(a=>a.label), datasets: [{ data: fp.investments.allocation.map(a=>a.pct) }] },
-          options: { plugins: { legend: { display: true, position: 'bottom' } }, cutout: '60%' }
-        });
-      }
-      const line = byId('fp-portfolio-line');
-      if (line && fp.investments && Array.isArray(fp.investments.history)) {
-        if (line._chart) line._chart.destroy();
-        line._chart = new Chart(line, {
-          type: 'line',
-          data: { labels: fp.investments.history.map(h=>h.label), datasets: [{ data: fp.investments.history.map(h=>h.value), borderWidth:2, fill:false, tension:.2 }] },
-          options: { plugins: { legend: { display: false } }, scales: { y: { ticks: { callback: v => '£'+Number(v).toLocaleString() } } } }
-        });
-      }
-    }
-    // Top costs table with trend
-    const tbody = byId('fp-top-costs-body');
-    if (tbody && trends?.expensesTop) {
-      tbody.innerHTML = '';
-      for (const c of trends.expensesTop) {
-        const ch = Number(c.changePct || 0);
-        const cls = ch > 0 ? 'text-danger' : ch < 0 ? 'text-success' : 'text-muted';
-        const arrow = ch > 0 ? '▲' : ch < 0 ? '▼' : '•';
-        const tr = document.createElement('tr');
-        tr.innerHTML = `
-          <td>${escapeHtml(c.name)}</td>
-          <td class="text-end">${money(c.amount)}</td>
-          <td class="text-end ${cls}"><span class="fw-semibold">${arrow} ${Math.abs(ch)}%</span></td>
-        `;
-        tbody.appendChild(tr);
-      }
+  // ----- Utilities -----
+  function byId(id) { return document.getElementById(id); }
+  function setText(id, value) { const el = byId(id); if (el) el.textContent = value ?? '—'; }
+  function toggleEmpty(id, show) {
+    const el = byId(id);
+    if (!el) return;
+    el.classList.toggle('d-none', !show);
+  }
+  function softError(message) {
+    const container = document.querySelector('.page-title');
+    if (container) {
+      const alert = document.createElement('div');
+      alert.className = 'alert alert-danger mt-3';
+      alert.textContent = message;
+      container.insertAdjacentElement('afterend', alert);
     }
   }
-
-  // ---- utils
-  function byId(id){ return document.getElementById(id); }
-  function setText(id, txt) { const el = byId(id); if (el) el.textContent = txt; }
-  function softError(msg) {
-    const wf = byId('chart-waterfall');
-    if (wf) wf.insertAdjacentHTML('beforebegin', `<div class="text-danger small">${escapeHtml(msg)}</div>`);
+  function safeTaxYearLabel(date) {
+    const y = date.getFullYear();
+    const start = new Date(y, 3, 6);
+    return date >= start ? `${y}/${String((y + 1) % 100).padStart(2, '0')}` : `${y - 1}/${String(y % 100).padStart(2, '0')}`;
   }
-  function safeTaxYearLabel(d) {
-    const y = d.getFullYear(), start = new Date(y, 3, 6);
-    return d >= start ? `${y}/${String((y+1)%100).padStart(2,'0')}` : `${y-1}/${String(y%100).padStart(2,'0')}`;
+  function money(value) {
+    const num = Number(value || 0);
+    const prefix = num < 0 ? '-£' : '£';
+    return `${prefix}${Math.abs(num).toLocaleString()}`;
   }
-  function money(n){ return '£' + Number(n || 0).toLocaleString(); }
-  function escapeHtml(s){ return String(s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+  function escapeHtml(str) {
+    return String(str || '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+  function themeColors(n) {
+    const root = getComputedStyle(document.documentElement);
+    const palette = ['--chart-1','--chart-2','--chart-3','--chart-4','--chart-5','--chart-6','--chart-7','--chart-8']
+      .map((v) => root.getPropertyValue(v).trim())
+      .filter(Boolean);
+    const fallback = ['#4a78ff','#60c8ff','#7dd3a8','#f5a524','#ef4d72','#8b5cf6','#f59e0b','#10b981'];
+    const base = palette.length ? palette : fallback;
+    return Array.from({ length: n }, (_, i) => base[i % base.length]);
+  }
 })();

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -2,11 +2,76 @@
 (async function injectNav() {
   try {
     const top = await fetch('/components/topbar.html', { cache: 'no-store' });
-    if (top.ok) document.getElementById('topbar-container')?.insertAdjacentHTML('beforeend', await top.text());
+    if (top.ok) {
+      document.getElementById('topbar-container')?.insertAdjacentHTML('beforeend', await top.text());
+      wireCountryToggle();
+      hydrateTopbarMeta();
+    }
     const side = await fetch('/components/sidebar.html', { cache: 'no-store' });
     if (side.ok) document.getElementById('sidebar-container')?.insertAdjacentHTML('beforeend', await side.text());
   } catch (e) { console.warn('nav inject failed', e); }
 })();
+
+async function hydrateTopbarMeta() {
+  try {
+    if (!window.Auth || typeof Auth.getCurrentUser !== 'function') return;
+    const me = await Auth.getCurrentUser();
+    if (!me) return;
+    const meta = document.getElementById('topbar-user-meta');
+    if (meta) {
+      const tier = (me.licenseTier || '').replace(/\b\w/g, (c) => c.toUpperCase());
+      const verified = me.emailVerified ? '<span class="badge text-bg-success ms-2">Verified</span>' : '<span class="badge text-bg-warning text-dark ms-2">Verify email</span>';
+      meta.innerHTML = `${tier || 'Free'} plan${verified}`;
+    }
+    const activeCountryBtn = document.querySelector(`#country-toggle [data-country="${me.country || 'uk'}"]`);
+    setCountryActive(activeCountryBtn);
+  } catch (err) {
+    console.warn('hydrateTopbarMeta failed', err);
+  }
+}
+
+function wireCountryToggle() {
+  const group = document.getElementById('country-toggle');
+  if (!group) return;
+
+  group.addEventListener('click', async (ev) => {
+    const btn = ev.target.closest('button[data-country]');
+    if (!btn || btn.classList.contains('disabled')) return;
+    setCountryActive(btn);
+    try {
+      if (window.Auth && typeof Auth.fetch === 'function') {
+        await Auth.fetch('/api/user/me', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            country: btn.dataset.country,
+            firstName: Auth.me?.firstName || '',
+            lastName: Auth.me?.lastName || '',
+            email: Auth.me?.email || ''
+          })
+        });
+        if (Auth.me) {
+          Auth.me.country = btn.dataset.country;
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to persist country preference', err);
+    }
+  });
+}
+
+function setCountryActive(btn) {
+  if (!btn) return;
+  const group = btn.closest('#country-toggle');
+  if (!group) return;
+  group.querySelectorAll('button[data-country]').forEach((el) => {
+    el.classList.remove('active');
+    el.classList.toggle('btn-outline-primary', false);
+    el.classList.toggle('btn-outline-secondary', el.dataset.country === 'us');
+  });
+  btn.classList.add('active');
+  btn.classList.toggle('btn-outline-primary', true);
+}
 
 // Global sign-out handler (works for dynamically inserted navs)
 document.addEventListener('click', (ev) => {

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -129,14 +129,70 @@
         <!-- Card side -->
         <section class="reveal">
           <div class="auth-card">
-            <h2 class="h5 mb-2 text-center">Sign up</h2>
+            <h2 class="h5 mb-2 text-center">Start your 30 day free trial</h2>
 
-            <!-- Visual parity block -->
-            <div class="phloat-lockup">PHLOAT</div>
-            <div class="divider small text-muted text-center"><span>or</span></div>
+            <div class="alert alert-light border small">
+              Choose a tier to preview every capability. Payment details are required to activate the trial. Cancel anytime within 30 days.
+            </div>
 
-            <!-- FORM: all fields/IDs/dynamics unchanged -->
-            <form id="signupForm" class="" novalidate>
+            <form id="signupForm" novalidate>
+              <div class="mb-3">
+                <label class="form-label">Choose your plan</label>
+                <div class="row g-2" id="plan-options">
+                  <div class="col-12">
+                    <label class="form-check card border rounded-4 p-3 w-100">
+                      <div class="d-flex justify-content-between align-items-center">
+                        <div>
+                          <input class="form-check-input" type="radio" name="planTier" value="starter" checked>
+                          <span class="ms-2 fw-semibold">Starter</span>
+                          <div class="text-muted small">Compliance essentials, smart document vault, HMRC sync.</div>
+                        </div>
+                        <span class="badge text-bg-primary">£29/mo after trial</span>
+                      </div>
+                    </label>
+                  </div>
+                  <div class="col-12">
+                    <label class="form-check card border rounded-4 p-3 w-100">
+                      <div class="d-flex justify-content-between align-items-center">
+                        <div>
+                          <input class="form-check-input" type="radio" name="planTier" value="growth">
+                          <span class="ms-2 fw-semibold">Growth</span>
+                          <div class="text-muted small">Automations, AI accountant suggestions, multi-entity management.</div>
+                        </div>
+                        <span class="badge text-bg-primary">£59/mo after trial</span>
+                      </div>
+                    </label>
+                  </div>
+                  <div class="col-12">
+                    <label class="form-check card border rounded-4 p-3 w-100">
+                      <div class="d-flex justify-content-between align-items-center">
+                        <div>
+                          <input class="form-check-input" type="radio" name="planTier" value="premium">
+                          <span class="ms-2 fw-semibold">Premium</span>
+                          <div class="text-muted small">Scenario lab, salary navigator and wealth strategy lab.</div>
+                        </div>
+                        <span class="badge text-bg-primary">£119/mo after trial</span>
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2 mb-3">
+                <div class="col-8">
+                  <label class="form-label">Coupon code</label>
+                  <input id="couponCode" class="form-control" placeholder="Optional">
+                  <div class="form-text">Use <strong>phloatadmin1998</strong> for unlimited premium testing.</div>
+                </div>
+                <div class="col-4">
+                  <label class="form-label">Country</label>
+                  <select id="country" class="form-select">
+                    <option value="uk" selected>United Kingdom</option>
+                    <option value="us" disabled>United States (coming soon)</option>
+                  </select>
+                </div>
+              </div>
+
               <div class="mb-3">
                 <label class="form-label">First name</label>
                 <input id="firstName" name="firstName" class="form-control" autocomplete="given-name" required>
@@ -181,7 +237,55 @@
                 <div class="form-text error text-danger small" data-error-for="passwordConfirm"></div>
               </div>
 
-              <!-- Required legal acceptance -->
+              <div class="mb-3">
+                <label class="form-label">Trial goals</label>
+                <div class="d-flex flex-wrap gap-2" id="goal-options">
+                  <label class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" value="saving">
+                    <span class="form-check-label">Saving</span>
+                  </label>
+                  <label class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" value="growing">
+                    <span class="form-check-label">Growing</span>
+                  </label>
+                  <label class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" value="analysing">
+                    <span class="form-check-label">Analysing</span>
+                  </label>
+                </div>
+              </div>
+
+              <div class="mt-3 mb-3">
+                <h3 class="h6">Payment details</h3>
+                <div class="row g-2">
+                  <div class="col-12">
+                    <label class="form-label">Card holder name</label>
+                    <input id="cardHolder" class="form-control" placeholder="Name as shown on card" required>
+                  </div>
+                  <div class="col-6">
+                    <label class="form-label">Card brand</label>
+                    <select id="cardBrand" class="form-select" required>
+                      <option value="Visa">Visa</option>
+                      <option value="Mastercard">Mastercard</option>
+                      <option value="American Express">American Express</option>
+                      <option value="Card">Other</option>
+                    </select>
+                  </div>
+                  <div class="col-6">
+                    <label class="form-label">Last 4 digits</label>
+                    <input id="cardLast4" class="form-control" maxlength="4" pattern="\d{4}" placeholder="1234" required>
+                  </div>
+                  <div class="col-6">
+                    <label class="form-label">Expiry month</label>
+                    <input id="cardExpMonth" type="number" min="1" max="12" class="form-control" placeholder="MM" required>
+                  </div>
+                  <div class="col-6">
+                    <label class="form-label">Expiry year</label>
+                    <input id="cardExpYear" type="number" min="2024" class="form-control" placeholder="YYYY" required>
+                  </div>
+                </div>
+              </div>
+
               <div class="col-12 mb-3">
                 <div class="form-check">
                   <input class="form-check-input" type="checkbox" id="agreeLegal" required>
@@ -192,10 +296,9 @@
                 <div class="form-text error" data-error-for="agreeLegal"></div>
               </div>
 
-              <!-- General error (kept) -->
               <div id="signup-error" class="text-danger small d-none mb-2"></div>
 
-              <button id="signupBtn" class="btn btn-primary w-100" type="submit">Create account</button>
+              <button id="signupBtn" class="btn btn-primary w-100" type="submit">Start free trial</button>
             </form>
 
             <p class="small text-center mt-2 text-secondary mb-0">


### PR DESCRIPTION
## Summary
- extend the user and subscription models with onboarding, trial, integration, salary, and wealth planning metadata plus email verification tokens
- add analytics and integration API routes, a mailer service, and overhaul auth/signup flows to support tier selection, coupons, payment capture, and verified email sign-in
- refresh the dashboard, nav, and signup experiences with country switching, premium feature gating, AI insight scaffolding, and improved styling hooks

## Testing
- `npm install` *(fails: registry access forbidden in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e144dfbffc8321878ebf9ea6972150