### PR TITLE
Fix profile auth flow and deliver responsive mobile experience

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -4,7 +4,12 @@ const bcrypt = require('bcryptjs');
 const auth = require('../middleware/auth');
 const User = require('../models/User');
 const PaymentMethod = require('../models/PaymentMethod');
-const PDFDocument = require('pdfkit');
+let PDFDocument = null;
+try {
+  PDFDocument = require('pdfkit');
+} catch (err) {
+  console.warn('⚠️  pdfkit not available – PDF exports will be disabled.');
+}
 const { randomUUID } = require('crypto');
 
 const router = express.Router();
@@ -502,6 +507,9 @@ router.post('/salary-navigator/benchmark', auth, async (req, res) => {
 // GET /api/user/salary-navigator/export
 router.get('/salary-navigator/export', auth, async (req, res) => {
   try {
+    if (!PDFDocument) {
+      return res.status(503).json({ error: 'PDF export is unavailable on this server.' });
+    }
     const user = await User.findById(req.user.id);
     if (!user) return res.status(404).json({ error: 'User not found' });
     const nav = decorateSalaryNavigator(user.salaryNavigator || {});
@@ -616,6 +624,9 @@ router.post('/wealth-plan/rebuild', auth, async (req, res) => {
 // GET /api/user/wealth-plan/export
 router.get('/wealth-plan/export', auth, async (req, res) => {
   try {
+    if (!PDFDocument) {
+      return res.status(503).json({ error: 'PDF export is unavailable on this server.' });
+    }
     const user = await User.findById(req.user.id);
     if (!user) return res.status(404).json({ error: 'User not found' });
     const plan = decorateWealth(user.wealthPlan || {});

--- a/backend/src/routes/user.routes.js
+++ b/backend/src/routes/user.routes.js
@@ -1,11 +1,15 @@
 // backend/src/routes/user.routes.js
-const express = require('express');
-const router = express.Router();
+// Bridge module that re-exports the primary user router defined in ../routes/user.js.
+// This ensures legacy require paths continue working without serving stale stub data.
 
-// Minimal /api/user/me for dashboard greeting
-router.get('/me', (req, res) => {
-  // If you already have auth, replace this with real user extraction
-  res.json({ id: 'demo', email: 'demo@example.com', firstName: 'Alex' });
-});
-
-module.exports = router;
+try {
+  module.exports = require('../../routes/user');
+} catch (err) {
+  console.error('Failed to load backend/routes/user.js from src/routes/user.routes.js bridge.', err);
+  const express = require('express');
+  const router = express.Router();
+  router.use((req, res) => {
+    res.status(503).json({ error: 'User service unavailable' });
+  });
+  module.exports = router;
+}

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -32,14 +32,21 @@
     --bs-link-color:var(--brand); --bs-link-hover-color:var(--brand-hover);
   }
   
-  /* base */
-  html,body{background:var(--bg-body); color:var(--fg)}
-  h1,h2,h3,h4,h5,h6{color:var(--fg); letter-spacing:.1px}
-  .card,.modal-content,.dropdown-menu,.list-group-item,.form-control,
-  .form-select,.btn,.alert,.badge,.progress,.toast{border-radius:var(--radius)}
-  a,button,.btn,.list-group-item,.nav-link,.form-control,.form-select{
-    transition:all 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+/* base */
+html,body{background:var(--bg-body); color:var(--fg)}
+h1,h2,h3,h4,h5,h6{color:var(--fg); letter-spacing:.1px}
+.card,.modal-content,.dropdown-menu,.list-group-item,.form-control,
+.form-select,.btn,.alert,.badge,.progress,.toast{border-radius:var(--radius)}
+a,button,.btn,.list-group-item,.nav-link,.form-control,.form-select{
+  transition:all 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+@media (max-width: 767.98px){
+  .container, .container-fluid{
+    padding-left: max(1rem, env(safe-area-inset-left));
+    padding-right: max(1rem, env(safe-area-inset-right));
   }
+}
   
   /* navbar */
   .navbar{background:var(--bg-surface)!important;border-bottom:1px solid var(--bd-hairline)}
@@ -158,12 +165,20 @@
 .app-topbar{
   position: fixed; inset: 0 0 auto 0;
   height: var(--topbar-h);
-  background: var(--bg-surface);
-  border-bottom: 1px solid var(--bd-hairline);
+  background: color-mix(in oklab, var(--bg-surface) 85%, transparent);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid color-mix(in oklab, var(--bd-hairline) 65%, transparent);
+  box-shadow: 0 12px 28px rgba(12,21,32,0.08);
   display: grid;
   grid-template-columns: 56px 1fr 56px; /* burger | center | right */
   align-items: center;
   z-index: 1020;
+  transition: background .2s ease, box-shadow .2s ease;
+}
+.app-topbar::after{
+  content:""; position:absolute; inset:0;
+  background: linear-gradient(180deg, rgba(255,255,255,0.55), rgba(255,255,255,0));
+  pointer-events:none;
 }
 .topbar-burger{
   margin-left: 8px;
@@ -177,6 +192,18 @@
   display: inline-flex; align-items: center; gap: .5rem; font-weight: 600;
 }
 .topbar-right{ justify-self: end; padding-right: 8px; }
+
+@media (max-width: 767.98px){
+  :root{ --topbar-h: 64px; }
+  .app-topbar{
+    grid-template-columns: 48px 1fr 48px;
+    padding-inline: clamp(0.75rem, 4vw, 1.25rem);
+  }
+  .topbar-logo{
+    font-size: 0.95rem;
+    gap: 0.4rem;
+  }
+}
 
 /* Sidebar container */
 .app-sidebar{
@@ -212,6 +239,12 @@
 .app-nav-item .label{
   white-space: nowrap; opacity: 0; transform: translateX(-8px);
   transition: opacity .16s ease, transform .16s ease;
+}
+
+@media (max-width: 991.98px){
+  .app-nav{ padding: 16px; gap: 8px; }
+  .app-nav-item{ padding: 14px 16px; border-radius: 16px; }
+  .app-nav-item i{ font-size: 1.2rem; }
 }
 
 /* Active + hover states */

--- a/frontend/js/profile.js
+++ b/frontend/js/profile.js
@@ -1,1682 +1,416 @@
 // frontend/js/profile.js
 (function () {
-  let USER = null;
-  let SUBSCRIPTION = null;
-  let PLANS = [];
-  let PLAN_BY_ID = {};
-  let PAYMENT_METHODS = [];
-  let PLAID_ITEMS = [];
-  let PLAID_BINDINGS_READY = false;
-  let PLAID_SCRIPT_PROMISE = null;
-
-  const $ = (sel, root=document) => root.querySelector(sel);
-  const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
-
-  const normaliseKey = (key='') => String(key).toLowerCase();
-  const slugify = (text='') => String(text).toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-  const escapeHtml = (str='') => String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-  const escapeAttr = (str='') => escapeHtml(str);
-
-  const fmtMoney = (n, curr='GBP') => {
-    const sym = curr === 'GBP' ? '£' : (curr === 'EUR' ? '€' : '$');
-    const val = Number(n || 0);
-    return `${sym}${val.toFixed(2)}`;
+  const state = {
+    user: null,
+    subscription: null,
+    plans: [],
+    paymentMethods: []
   };
-  const isoToNice = (d) => d ? new Date(d).toLocaleString() : '—';
-  const isoToDate = (d) => d ? new Date(d).toLocaleDateString() : '—';
-  const daysBetween = (a, b) => {
-    const ms = Math.abs(new Date(b).getTime() - new Date(a).getTime());
-    return Math.floor(ms / (1000*60*60*24));
-  };
-  const cap = (s) => String(s || '').slice(0,1).toUpperCase() + String(s || '').slice(1);
-  const escapeHtml = (s='') => String(s)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
 
-  function setTileGrid(stats) {
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+  const moneyFormatter = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 2 });
+
+  function fmtMoney(amount, currency = 'GBP') {
+    try {
+      return new Intl.NumberFormat('en-GB', { style: 'currency', currency }).format(Number(amount || 0));
+    } catch {
+      return moneyFormatter.format(Number(amount || 0));
+    }
+  }
+
+  function isoToNice(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '—';
+    return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  }
+
+  function isoToDate(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '—';
+    return date.toLocaleDateString(undefined, { dateStyle: 'medium' });
+  }
+
+  function cap(text) {
+    const str = String(text || '');
+    return str.slice(0, 1).toUpperCase() + str.slice(1);
+  }
+
+  function daysBetween(start, end = new Date()) {
+    if (!start) return '—';
+    const a = new Date(start);
+    const b = new Date(end);
+    if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return '—';
+    const diff = Math.abs(b.getTime() - a.getTime());
+    return Math.max(1, Math.round(diff / (1000 * 60 * 60 * 24)));
+  }
+
+  function cacheUser(user) {
+    if (!user) return;
+    window.__ME__ = user;
+    try { localStorage.setItem('me', JSON.stringify(user)); } catch {}
+    try { sessionStorage.setItem('me', JSON.stringify(user)); } catch {}
+    if (typeof window.hydrateTopbarMeta === 'function') {
+      try { window.hydrateTopbarMeta(); } catch (err) { console.warn('hydrateTopbarMeta failed', err); }
+    }
+  }
+
+  function planFor(id) {
+    if (!id) return null;
+    const uiId = String(id).toLowerCase() === 'premium' ? 'professional' : String(id).toLowerCase();
+    return state.plans.find((plan) => plan.id === uiId) || null;
+  }
+
+  function currentPlanId() {
+    const tier = state.subscription?.licenseTier || state.user?.licenseTier || 'free';
+    return String(tier || 'free').toLowerCase();
+  }
+
+  function currentInterval() {
+    return String(state.subscription?.subscription?.interval || 'monthly').toLowerCase();
+  }
+
+  function showStatus(message, variant = 'info') {
+    const box = $('#profile-status');
+    if (!box) return;
+    if (!message) {
+      box.classList.add('d-none');
+      box.textContent = '';
+      return;
+    }
+    box.className = `alert alert-${variant} border border-${variant}-subtle mb-3`;
+    box.textContent = message;
+  }
+
+  function setTileGrid(tiles) {
     const wrap = $('#stat-tiles');
+    if (!wrap) return;
     wrap.innerHTML = '';
+    tiles.forEach((tile) => {
+      const node = document.createElement('div');
+      node.className = 'tile';
+      node.innerHTML = `
+        <div class="k">${tile.label}</div>
+        <div class="v">
+          <span>${tile.value}</span>
+          ${tile.meta ? `<span class="delta ${tile.metaTone || ''}">${tile.meta}</span>` : ''}
+        </div>
+      `;
+      wrap.appendChild(node);
+    });
+  }
+
+  function computeStats() {
+    if (!state.user) return;
+    const planId = currentPlanId();
+    const interval = currentInterval();
+    const plan = planFor(planId);
+    const uiPlanId = plan ? plan.id : (planId === 'premium' ? 'professional' : planId);
+
+    let planLabel = cap(uiPlanId || 'free');
+    if (planLabel === 'Professional') planLabel = 'Premium';
+    const cadenceLabel = interval === 'yearly' ? 'Yearly' : 'Monthly';
+
+    const price = plan
+      ? (interval === 'yearly' ? plan.priceYearly : plan.priceMonthly)
+      : 0;
+    const priceDisplay = plan ? `${fmtMoney(price, plan.currency)} / ${interval === 'yearly' ? 'yr' : 'mo'}` : '—';
+
+    const emailStatus = state.user.emailVerified ? 'Verified' : 'Awaiting verification';
+    const emailTone = state.user.emailVerified ? 'up' : 'down';
+    const emailMeta = state.user.emailVerified ? 'All secure' : 'Verify in settings';
 
     const tiles = [
-      { k: 'Money saved', v: stats.moneySavedText, delta: stats.moneySavedDelta, deltaDir: stats.moneySavedDeltaDir },
-      { k: 'Reports generated', v: stats.reportsGenerated ?? '—', delta: null },
-      { k: 'Net worth change', v: stats.netWorthChange ?? '—', delta: stats.netWorthDelta, deltaDir: (stats.netWorthDelta||'').startsWith('-') ? 'down' : 'up' },
-      { k: 'Days on platform', v: stats.daysOnPlatform ?? '—', delta: null },
-      { k: 'Current plan', v: stats.planLabel ?? '—', delta: null },
-      { k: 'Plan cost', v: stats.planCost ?? '—', delta: stats.planCycle, deltaDir: 'up' },
+      { label: 'Plan', value: planLabel },
+      { label: 'Billing cadence', value: cadenceLabel },
+      { label: 'Plan cost', value: priceDisplay, meta: plan ? (interval === 'yearly' ? 'Best value' : 'Switch to yearly and save') : null, metaTone: interval === 'yearly' ? 'up' : 'info' },
+      { label: 'Days with Phloat', value: `${daysBetween(state.user.createdAt)} days` },
+      { label: 'Email status', value: emailStatus, meta: emailMeta, metaTone: emailTone },
+      { label: 'Profile refreshed', value: isoToDate(state.user.updatedAt) }
     ];
 
-    for (const t of tiles) {
-      const div = document.createElement('div');
-      div.className = 'tile';
-      div.innerHTML = `
-        <div class="k">${t.k}</div>
-        <div class="v">
-          <span>${t.v}</span>
-          ${t.delta ? `<span class="delta ${t.deltaDir || ''}">${t.delta}</span>` : ''}
-        </div>
-      `;
-      wrap.appendChild(div);
-    }
-  }
-
-  function featureListFor(planUiId) {
-    const p = PLANS.find(x => String(x.id) === String(planUiId));
-    return Array.isArray(p?.features) ? p.features : [];
-  }
-
-  function moneySavedStat(planUiId, interval) {
-    const def = PLANS.find(p => p.id === planUiId);
-    if (!def) return { text: '—', delta: null, dir: null };
-
-    if (interval === 'yearly') {
-      const monthly = Number(def.priceMonthly || 0) * 12;
-      const yearly  = Number(def.priceYearly  || 0);
-      const saved   = Math.max(monthly - yearly, 0);
-      return { text: fmtMoney(saved, def.currency), delta: 'vs monthly', dir: 'up' };
-    } else if (interval === 'monthly') {
-      const monthly = Number(def.priceMonthly || 0) * 12;
-      const yearly  = Number(def.priceYearly  || 0);
-      const couldSave = Math.max(monthly - yearly, 0);
-      return { text: fmtMoney(couldSave, def.currency), delta: 'if yearly', dir: 'up' };
-    } else {
-      return { text: '—', delta: null, dir: null };
-    }
-  }
-
-  function normaliseCatalogItem(raw) {
-    return {
-      key: normaliseKey(raw?.key),
-      label: raw?.label || 'Integration',
-      category: raw?.category || 'Data source',
-      description: raw?.description || '',
-      comingSoon: !!raw?.comingSoon,
-      docsUrl: raw?.docsUrl || null,
-      help: raw?.help || null,
-      requiredEnv: Array.isArray(raw?.requiredEnv) ? raw.requiredEnv : [],
-      missingEnv: Array.isArray(raw?.missingEnv) ? raw.missingEnv : [],
-      envReady: raw?.envReady !== false,
-      defaultStatus: raw?.defaultStatus || (raw?.comingSoon ? 'pending' : 'not_connected'),
-      isCatalog: true,
-      metadata: {}
-    };
-  }
-
-  function mergeIntegrations(catalog, userIntegrations) {
-    const map = new Map();
-    for (const item of catalog) {
-      map.set(item.key, {
-        ...item,
-        status: item.defaultStatus || 'not_connected',
-        metadata: {},
-        lastCheckedAt: null
-      });
-    }
-    for (const entry of (userIntegrations || [])) {
-      const key = normaliseKey(entry?.key);
-      if (!key) continue;
-      const existing = map.get(key);
-      if (existing) {
-        map.set(key, {
-          ...existing,
-          status: entry.status || existing.status,
-          metadata: entry.metadata || existing.metadata || {},
-          lastCheckedAt: entry.lastCheckedAt || existing.lastCheckedAt
-        });
-      } else {
-        map.set(key, {
-          key,
-          label: entry.label || cap(key),
-          category: entry.metadata?.category || 'Custom data source',
-          description: entry.metadata?.description || '',
-          comingSoon: false,
-          docsUrl: null,
-          help: null,
-          requiredEnv: [],
-          missingEnv: [],
-          envReady: true,
-          defaultStatus: entry.status || 'not_connected',
-          status: entry.status || 'not_connected',
-          metadata: entry.metadata || {},
-          lastCheckedAt: entry.lastCheckedAt || null,
-          isCatalog: false
-        });
-      }
-    }
-    return Array.from(map.values()).sort((a, b) => {
-      const orderA = STATUS_ORDER[a.status] ?? 9;
-      const orderB = STATUS_ORDER[b.status] ?? 9;
-      if (orderA !== orderB) return orderA - orderB;
-      if (a.comingSoon !== b.comingSoon) return a.comingSoon ? 1 : -1;
-      return (a.label || '').localeCompare(b.label || '');
-    });
-  }
-
-  function updateIntegrationSummary() {
-    const summary = $('#integration-summary');
-    if (!summary) return;
-    if (!INTEGRATION_CATALOG.length) {
-      summary.textContent = 'Loading integration catalogue…';
-      return;
-    }
-
-    const bankConnections = INTEGRATIONS.filter((item) => isBankConnection(item) && !item.comingSoon);
-    const connectedBanks = bankConnections.filter((item) => item.status === 'connected').length;
-    const pendingBanks = bankConnections.filter((item) => item.status === 'pending' || item.status === 'error').length;
-
-    const tlCatalog = INTEGRATION_CATALOG.find((item) => item.key === 'truelayer');
-    const hmrcCatalog = INTEGRATION_CATALOG.find((item) => item.key === 'hmrc');
-
-    let text = '';
-    if (connectedBanks) {
-      text = `${connectedBanks} bank connection${connectedBanks === 1 ? '' : 's'} active via TrueLayer`;
-      if (pendingBanks) text += ` · ${pendingBanks} awaiting renewal`;
-    } else if (bankConnections.length) {
-      text = 'Bank connections added — renew to activate sync.';
-    } else if (tlCatalog?.missingEnv?.length) {
-      text = `Add ${tlCatalog.missingEnv.join(', ')} in Render to launch TrueLayer.`;
-    } else {
-      text = 'No live integrations yet — connect your bank to unlock automations.';
-    }
-
-    if (hmrcCatalog?.comingSoon) {
-      text += ' · HMRC Making Tax Digital coming soon';
-    }
-
-    summary.textContent = text;
-  }
-
-  function showIntegrationFlash(type, message='') {
-    const flash = $('#integration-flash');
-    if (!flash) return;
-    if (!type) {
-      flash.innerHTML = '';
-      return;
-    }
-    const map = { success: 'success', error: 'danger', warning: 'warning', info: 'info' };
-    const variant = map[type] || 'info';
-    flash.innerHTML = `<div class="alert alert-${variant} border border-${variant}-subtle">${escapeHtml(message)}</div>`;
-  }
-
-  function renderIntegrations() {
-    const wrap = $('#integration-list');
-    if (!wrap) return;
-    wrap.classList.remove('opacity-50');
-    wrap.innerHTML = '';
-
-    if (!INTEGRATIONS.length && !INTEGRATION_CATALOG.length) {
-      wrap.innerHTML = '<div class="text-muted small">Integration catalogue is loading…</div>';
-      updateIntegrationSummary();
-      return;
-    }
-
-    const baseItems = INTEGRATIONS.filter((item) => !isBankConnection(item));
-    if (!baseItems.length) {
-      wrap.innerHTML = '<div class="text-muted small">Integration catalogue is loading…</div>';
-      updateIntegrationSummary();
-      return;
-    }
-
-    for (const integration of baseItems) {
-      const providerKey = normaliseKey(integration.key);
-      const connections = getConnectionsForProvider(providerKey);
-      const displayStatus = statusForProvider(integration, connections);
-      const statusMeta = STATUS_META[displayStatus] || STATUS_META.not_connected;
-      const envMissing = Array.isArray(integration.missingEnv) && integration.missingEnv.length;
-      const card = document.createElement('div');
-      card.className = 'integration-card';
-      card.dataset.key = integration.key;
-      card.dataset.status = displayStatus;
-      card.dataset.kind = 'provider';
-
-      const docsLink = integration.docsUrl ? `<a href="${integration.docsUrl}" target="_blank" rel="noopener">Docs</a>` : '';
-      const description = integration.description || (integration.comingSoon ? 'This connection is on the way — we will let you know as soon as it is ready.' : 'Connect to stream live financial data into your analytics.');
-      const connectionBadge = providerKey === 'truelayer'
-        ? `<span class="integration-badge">${connections.length ? `${connections.length} bank${connections.length === 1 ? '' : 's'} configured` : 'No banks linked yet'}</span>`
-        : '';
-
-      const metaParts = [statusMeta.label];
-      if (providerKey === 'truelayer' && connections.length) {
-        const connectedCount = connections.filter((c) => c.status === 'connected').length;
-        const inactiveCount = connections.length - connectedCount;
-        metaParts.push(`${connectedCount} active`);
-        if (inactiveCount > 0) metaParts.push(`${inactiveCount} inactive`);
-      }
-      if (integration.lastCheckedAt) metaParts.push(`Updated ${isoToNice(integration.lastCheckedAt)}`);
-      if (docsLink) metaParts.push(docsLink);
-
-      const actions = [];
-      if (integration.comingSoon) {
-        actions.push('<button class="btn btn-sm btn-secondary" type="button" disabled>Coming soon</button>');
-      } else if (providerKey === 'truelayer') {
-        const primaryLabel = connections.length ? 'Add another bank' : 'Connect bank';
-        const disabledAttr = envMissing ? ' disabled' : '';
-        actions.push(`<button class="btn btn-sm btn-primary" data-action="connect"${disabledAttr}>${primaryLabel}</button>`);
-        actions.push('<button class="btn btn-sm btn-outline-secondary" data-action="manage">Manage</button>');
-      } else if (!integration.isCatalog) {
-        actions.push(`<button class="btn btn-sm btn-primary" data-action="connect">${integration.status === 'connected' ? 'Manage connection' : 'Connect'}</button>`);
-        actions.push('<button class="btn btn-sm btn-outline-secondary" data-action="edit">Edit</button>');
-        actions.push('<button class="btn btn-sm btn-link text-danger" data-action="delete">Delete</button>');
-      } else {
-        actions.push('<button class="btn btn-sm btn-outline-secondary" data-action="manage">Manage</button>');
-      }
-
-      const envNotice = (!integration.comingSoon && envMissing)
-        ? `<div class="alert alert-warning border border-warning-subtle small mb-0">Set up pending — add ${integration.missingEnv.map((v) => `<code>${escapeHtml(v)}</code>`).join(', ')} in Render before launching.</div>`
-        : '';
-
-      card.innerHTML = `
-        <div class="integration-card-header">
-          <span class="integration-status-dot ${statusMeta.dot}"></span>
-          <div class="flex-grow-1">
-            <div class="d-flex align-items-center gap-2 flex-wrap">
-              <h6>${escapeHtml(integration.label)}</h6>
-              ${integration.comingSoon ? '<span class="badge-coming-soon">Coming soon</span>' : connectionBadge}
-            </div>
-            <div class="meta">${escapeHtml(integration.category || 'Data source')}</div>
-          </div>
-        </div>
-        <div class="text-muted small">${escapeHtml(description)}</div>
-        ${envNotice}
-        <div class="integration-actions">
-          ${actions.join(' ')}
-        </div>
-        <div class="integration-meta">
-          ${metaParts.map((part) => `<span>${part}</span>`).join('')}
-        </div>
-      `;
-      wrap.appendChild(card);
-
-      if (connections.length) {
-        connections.sort((a, b) => (a.label || '').localeCompare(b.label || ''));
-        for (const connection of connections) {
-          wrap.appendChild(renderConnectionCard(connection));
-        }
-      }
-    }
-
-    updateIntegrationSummary();
-  }
-
-  function renderConnectionCard(connection) {
-    const statusMeta = STATUS_META[connection.status] || STATUS_META.not_connected;
-    const card = document.createElement('div');
-    card.className = 'integration-card';
-    card.dataset.key = connection.key;
-    card.dataset.status = connection.status;
-    card.dataset.kind = 'connection';
-
-    const institution = connection.metadata?.institution || {};
-    const bankMeta = bankById(institution.id) || {};
-    const brandColor = institution.brandColor || bankMeta.brandColor || '#4338ca';
-    const avatarContent = institution.icon || bankMeta.icon || bankInitials(institution.name || connection.label);
-    const statusText = STATUS_TEXT[connection.status] || (STATUS_META[connection.status]?.label ?? 'Status');
-    const accounts = Array.isArray(connection.metadata?.accounts) ? connection.metadata.accounts : [];
-    const accountSummaryText = accountsSummary(accounts);
-    const refreshed = connection.metadata?.lastRefreshedAt ? isoToNice(connection.metadata.lastRefreshedAt) : null;
-    const addedAt = connection.metadata?.addedAt ? isoToNice(connection.metadata.addedAt) : null;
-    const sandboxBadge = connection.metadata?.sandbox ? '<span class="connection-badge">Sandbox</span>' : '';
-
-    const metaPieces = [
-      `<span class="status-text">${escapeHtml(statusText)}</span>`,
-      `<span>${escapeHtml(accountSummaryText)}</span>`
-    ];
-    if (refreshed) metaPieces.push(`<span>Refreshed ${escapeHtml(refreshed)}</span>`);
-    else metaPieces.push('<span>Awaiting first sync</span>');
-    if (addedAt) metaPieces.push(`<span>Linked ${escapeHtml(addedAt)}</span>`);
-
-    card.innerHTML = `
-      <div class="integration-card-header">
-        <div class="connection-avatar" style="background:${brandColor}; box-shadow:0 12px 26px ${withAlpha(brandColor,0.35)};">
-          ${escapeHtml(avatarContent)}
-        </div>
-        <div class="flex-grow-1">
-          <div class="d-flex align-items-center gap-2 flex-wrap">
-            <h6>${escapeHtml(connection.label)}</h6>
-            <span class="connection-badge">via TrueLayer</span>
-            ${sandboxBadge}
-          </div>
-          <div class="meta">${escapeHtml(institution.tagline || accountSummaryText)}</div>
-        </div>
-        <span class="integration-status-dot ${statusMeta.dot}"></span>
-      </div>
-      <div class="integration-meta">
-        ${metaPieces.join('')}
-      </div>
-      <div class="integration-actions">
-        <button class="btn btn-sm btn-outline-secondary" data-action="edit">Edit</button>
-        <button class="btn btn-sm btn-primary" data-action="renew">Renew connection</button>
-        <button class="btn btn-sm btn-link text-danger" data-action="delete">Delete</button>
-      </div>
-    `;
-    return card;
-  }
-
-  function bindIntegrationEvents() {
-    const wrap = $('#integration-list');
-    if (wrap && !wrap.dataset.bound) {
-      wrap.dataset.bound = '1';
-      wrap.addEventListener('click', (event) => {
-        const btn = event.target.closest('[data-action]');
-        if (!btn) return;
-        if (btn.hasAttribute('disabled')) return;
-        const card = btn.closest('[data-key]');
-        if (!card) return;
-        const integration = INTEGRATIONS.find((i) => i.key === card.dataset.key);
-        if (!integration) return;
-        const action = btn.dataset.action;
-        const kind = card.dataset.kind || (isBankConnection(integration) ? 'connection' : 'provider');
-        if (action === 'delete') {
-          deleteIntegration(integration);
-        } else if (action === 'edit') {
-          openIntegrationSheet(integration, 'edit');
-        } else if (action === 'manage') {
-          openIntegrationSheet(integration, 'manage');
-        } else if (action === 'renew') {
-          renewIntegration(integration);
-        } else if (action === 'connect') {
-          if (kind === 'provider') openIntegrationSheet(integration, 'connect');
-          else openIntegrationSheet(integration, integration.status === 'connected' ? 'manage' : 'connect');
-        }
-      });
-    }
-
-    const sheet = $('#integration-sheet');
-    if (sheet && !sheet.dataset.bound) {
-      sheet.dataset.bound = '1';
-      sheet.addEventListener('click', (ev) => {
-        if (ev.target === sheet) closeIntegrationSheet();
-      });
-      sheet.querySelectorAll('[data-close-sheet]').forEach((btn) => btn.addEventListener('click', closeIntegrationSheet));
-    }
-
-    if (!document.body.dataset.integrationEsc) {
-      document.body.dataset.integrationEsc = '1';
-      document.addEventListener('keydown', (ev) => {
-        if (ev.key === 'Escape') closeIntegrationSheet();
-      });
-    }
-  }
-
-  function openIntegrationSheet(integration, mode='edit') {
-    const providerKey = normaliseKey(integration?.key || '');
-    if (providerKey === 'truelayer' && mode !== 'create' && !isBankConnection(integration)) {
-      renderTruelayerProviderSheet(integration, mode);
-      return;
-    }
-    if (isBankConnection(integration) && providerFrom(integration) === 'truelayer') {
-      renderTruelayerConnectionSheet(integration, mode);
-      return;
-    }
-    renderGenericIntegrationSheet(integration, mode);
-  }
-
-  function renderGenericIntegrationSheet(integration, mode='edit') {
-    const sheet = $('#integration-sheet');
-    if (!sheet) return;
-    ACTIVE_INTEGRATION = { ...integration, metadata: { ...(integration.metadata || {}) } };
-    SHEET_MODE = mode;
-
-    sheet.hidden = false;
-    requestAnimationFrame(() => sheet.classList.add('open'));
-
-    const meta = STATUS_META[integration.status] || STATUS_META.not_connected;
-    const title = $('#intg-sheet-title');
-    if (title) title.textContent = integration.label || (mode === 'create' ? 'Create integration' : 'Integration');
-    const subtitle = $('#intg-sheet-sub');
-    if (subtitle) subtitle.textContent = `${meta.label}${integration.category ? ` · ${integration.category}` : ''}`;
-
-    const sections = [];
-    if (integration.comingSoon && mode !== 'create') {
-      sections.push(`
-        <div class="alert alert-info border border-info-subtle">
-          Set up pending — HMRC requires production approval before we can finalise this connection. We will guide you through the activation as soon as access is granted.
-        </div>
-      `);
-    }
-    if (mode === 'create') {
-      sections.push(`
-        <div>
-          <label class="form-label">Display name</label>
-          <input type="text" class="form-control" id="intg-field-name" placeholder="e.g. Barclays Business" value="${escapeAttr(integration.label)}" />
-        </div>
-      `);
-      sections.push(`
-        <div>
-          <label class="form-label">Description</label>
-          <textarea class="form-control" id="intg-field-description" rows="2" placeholder="How will this data source be used?">${escapeHtml(integration.description || '')}</textarea>
-        </div>
-      `);
-    } else {
-      sections.push(`
-        <div>
-          <div class="small text-muted mb-1">About</div>
-          <p class="mb-0">${escapeHtml(integration.description || (integration.comingSoon ? 'This connection is being finalised. We will notify you when HMRC approves the connection.' : 'Launch the connection flow to pull live insights into Phloat.'))}</p>
-        </div>
-      `);
-    }
-
-    const options = Object.entries(STATUS_META)
-      .map(([value, m]) => `<option value="${value}" ${value === integration.status ? 'selected' : ''}>${m.label}</option>`)
-      .join('');
-    sections.push(`
-      <div>
-        <label class="form-label">Status</label>
-        <select class="form-select" id="intg-field-status" ${integration.comingSoon ? 'disabled' : ''}>
-          ${options}
-        </select>
-        <div class="form-text">${escapeHtml(meta.summary)}</div>
-      </div>
-    `);
-
-    const envList = Array.isArray(integration.requiredEnv) ? integration.requiredEnv : [];
-    if (envList.length) {
-      const missing = Array.isArray(integration.missingEnv) ? integration.missingEnv : [];
-      const missingSet = new Set(missing.map((m) => String(m).toUpperCase()));
-      const envRows = envList.map((name) => {
-        const missingEntry = missingSet.has(String(name).toUpperCase());
-        return `<li>${escapeHtml(name)} ${missingEntry ? '<span class="text-danger ms-1">Missing</span>' : '<span class="text-success ms-1">Detected</span>'}</li>`;
-      }).join('');
-      const alertClass = missing.length ? 'alert alert-warning border border-warning-subtle' : 'alert alert-success border border-success-subtle';
-      const heading = missing.length ? 'Set up pending — add these environment variables in Render:' : 'Environment variables detected:';
-      sections.push(`
-        <div class="${alertClass}">
-          <strong>${heading}</strong>
-          <ul class="env-list mt-2">${envRows}</ul>
-        </div>
-      `);
-    }
-
-    sections.push(`
-      <div>
-        <label class="form-label">Team notes</label>
-        <textarea class="form-control" id="intg-field-notes" rows="3" placeholder="Credentials, review cadence, anything the team should know.">${escapeHtml(integration.metadata?.notes || '')}</textarea>
-      </div>
-    `);
-
-    const body = $('#intg-sheet-body');
-    if (body) body.innerHTML = sections.join('');
-
-    const foot = $('#intg-sheet-footnote');
-    if (foot) {
-      const help = integration.help ? escapeHtml(integration.help) : '';
-      const docs = integration.docsUrl ? `<a href="${integration.docsUrl}" target="_blank" rel="noopener">Provider documentation</a>` : '';
-      foot.innerHTML = [help, docs].filter(Boolean).join(' · ');
-    }
-
-    const saveBtn = $('#intg-sheet-save');
-    if (saveBtn) {
-      saveBtn.style.display = '';
-      if (integration.comingSoon) {
-        saveBtn.disabled = true;
-        saveBtn.textContent = 'Coming soon';
-        saveBtn.onclick = null;
-      } else {
-        saveBtn.disabled = false;
-        saveBtn.textContent = mode === 'create' ? 'Create integration' : 'Save changes';
-        saveBtn.onclick = handleIntegrationSave;
-      }
-    }
-  }
-
-  function renderTruelayerProviderSheet(integration, mode='connect') {
-    const sheet = $('#integration-sheet');
-    if (!sheet) return;
-    ACTIVE_INTEGRATION = { ...integration, metadata: { ...(integration.metadata || {}) } };
-    SHEET_MODE = 'truelayer-connect';
-
-    const connections = getConnectionsForProvider('truelayer');
-    const displayStatus = statusForProvider(integration, connections);
-    const statusMeta = STATUS_META[displayStatus] || STATUS_META.not_connected;
-    const envMissing = Array.isArray(integration.missingEnv) && integration.missingEnv.length;
-
-    sheet.hidden = false;
-    requestAnimationFrame(() => sheet.classList.add('open'));
-
-    const title = $('#intg-sheet-title');
-    if (title) title.textContent = 'Link a bank via TrueLayer';
-    const subtitle = $('#intg-sheet-sub');
-    if (subtitle) subtitle.textContent = `${statusMeta.label} · Bank connections`;
-
-    const statusAlert = envMissing
-      ? `<div class="alert alert-warning border border-warning-subtle">TrueLayer credentials missing — add ${integration.missingEnv.map((v) => `<code>${escapeHtml(v)}</code>`).join(', ')} in Render to enable the flow.</div>`
-      : '<div class="alert alert-success border border-success-subtle">Credentials detected — you will be redirected to TrueLayer\'s secure consent journey to complete the connection.</div>';
-
-    const connectionSummary = connections.length
-      ? `<div class="small text-muted">Currently linked: ${connections.map((c) => escapeHtml(c.label)).join(', ')}.</div>`
-      : '<div class="small text-muted">No banks linked yet — choose an institution below to get started.</div>';
-
-    const cards = TL_BANK_LIBRARY.map((bank) => {
-      const gradient = bank.gradient || 'linear-gradient(140deg, rgba(99,102,241,.8), rgba(67,56,202,.65))';
-      const disabledAttr = envMissing ? ' aria-disabled="true"' : '';
-      const existing = connections.some((c) => (c.metadata?.institution?.id || '') === bank.id && c.status === 'connected');
-      const chipLabel = envMissing ? 'Awaiting setup' : (existing ? 'Add another' : 'Connect');
-      const iconSpan = bank.icon ? `<span>${escapeHtml(bank.icon)}</span>` : '';
-      return `
-        <div class="tl-bank-card" data-bank-id="${bank.id}" style="--bank-gradient:${gradient};"${disabledAttr}>
-          <div class="bank-name">${escapeHtml(bank.name)}</div>
-          <div class="bank-tagline">${escapeHtml(bank.tagline)}</div>
-          <div class="bank-chip">${iconSpan}<span>${escapeHtml(chipLabel)}</span></div>
-        </div>
-      `;
-    }).join('');
-
-    const body = $('#intg-sheet-body');
-    if (body) {
-      body.innerHTML = `
-        <div id="truelayer-status"></div>
-        <div class="tl-sheet-hero">
-          <div class="eyebrow">Open banking</div>
-          <h5>Connect your bank in seconds</h5>
-          <p>Phloat.io uses TrueLayer’s secure consent flow so you can link UK accounts with the same sleek experience you expect from modern fintech leaders.</p>
-        </div>
-        ${statusAlert}
-        ${connectionSummary}
-        <div class="tl-bank-grid mt-3">
-          ${cards}
-        </div>
-        <div class="tl-provider-picker mt-4">
-          <label class="form-label">Prefer a different provider?</label>
-          <div id="tl-provider-select-wrap" class="tl-provider-select-wrap">
-            <div class="text-muted small">Search the full TrueLayer directory or pick from the favourites above.</div>
-          </div>
-        </div>
-        <div class="tl-sheet-footnote mt-3">Selecting a bank launches the TrueLayer consent journey. We honour <code>TL_USE_SANDBOX</code> when configured so you can test safely before going live.</div>
-      `;
-    }
-
-    const foot = $('#intg-sheet-footnote');
-    if (foot) {
-      foot.innerHTML = '<a href="https://docs.truelayer.com/" target="_blank" rel="noopener">Review the TrueLayer documentation</a>';
-    }
-
-    const saveBtn = $('#intg-sheet-save');
-    if (saveBtn) {
-      saveBtn.style.display = 'none';
-      saveBtn.onclick = null;
-    }
-
-    sheet.querySelectorAll('[data-bank-id]').forEach((card) => {
-      card.addEventListener('click', () => {
-        if (card.getAttribute('aria-disabled') === 'true') return;
-        const bank = bankById(card.dataset.bankId);
-        if (!bank) return;
-        if (bank.id === 'other') {
-          populateTruelayerProviderPicker(true);
-          return;
-        }
-        launchTruelayerConnection(bank, card);
-      });
-    });
-
-    populateTruelayerProviderPicker();
-  }
-
-  function renderTruelayerConnectionSheet(integration, mode='edit') {
-    const sheet = $('#integration-sheet');
-    if (!sheet) return;
-    ACTIVE_INTEGRATION = { ...integration, metadata: { ...(integration.metadata || {}) } };
-    SHEET_MODE = mode;
-
-    const meta = STATUS_META[integration.status] || STATUS_META.not_connected;
-    const institution = integration.metadata?.institution || {};
-    const accounts = Array.isArray(integration.metadata?.accounts) ? integration.metadata.accounts : [];
-    const addedAt = integration.metadata?.addedAt ? isoToNice(integration.metadata.addedAt) : null;
-    const refreshed = integration.metadata?.lastRefreshedAt ? isoToNice(integration.metadata.lastRefreshedAt) : null;
-
-    sheet.hidden = false;
-    requestAnimationFrame(() => sheet.classList.add('open'));
-
-    const title = $('#intg-sheet-title');
-    if (title) title.textContent = integration.label || institution.name || 'Bank connection';
-    const subtitle = $('#intg-sheet-sub');
-    if (subtitle) subtitle.textContent = `TrueLayer · ${meta.label}`;
-
-    const accountItems = accounts.length
-      ? accounts.map((acct) => `<li>${escapeHtml(acct.type || acct.name || 'Account')}${acct.currency ? ` · ${escapeHtml(acct.currency)}` : ''}</li>`).join('')
-      : '<li>No account details captured yet.</li>';
-
-    const body = $('#intg-sheet-body');
-    if (body) {
-      body.innerHTML = `
-        <div class="alert alert-light border border-secondary-subtle d-flex flex-column gap-1">
-          <strong>${escapeHtml(institution.name || integration.label || 'Linked bank')}</strong>
-          <span>Connected via TrueLayer${addedAt ? ` · Linked ${escapeHtml(addedAt)}` : ''}${refreshed ? ` · Last refreshed ${escapeHtml(refreshed)}` : ''}</span>
-        </div>
-        <div class="row g-3">
-          <div class="col-12">
-            <label class="form-label">Display name</label>
-            <input type="text" class="form-control" id="intg-field-name" value="${escapeAttr(integration.metadata?.nickname || integration.label || institution.name || '')}" />
-          </div>
-          <div class="col-12 col-md-6">
-            <label class="form-label">Status</label>
-            <select class="form-select" id="intg-field-status">
-              ${Object.entries(STATUS_META).map(([value, m]) => `<option value="${value}" ${value === integration.status ? 'selected' : ''}>${m.label}</option>`).join('')}
-            </select>
-            <div class="form-text">Use “Inactive” if you want to pause sync without removing the connection.</div>
-          </div>
-          <div class="col-12 col-md-6">
-            <label class="form-label">Accounts captured</label>
-            <ul class="env-list mt-2">${accountItems}</ul>
-          </div>
-          <div class="col-12">
-            <label class="form-label">Notes</label>
-            <textarea class="form-control" id="intg-field-notes" rows="3" placeholder="Credentials, renewal cadence, anything the team should know.">${escapeHtml(integration.metadata?.notes || '')}</textarea>
-          </div>
-        </div>
-      `;
-    }
-
-    const foot = $('#intg-sheet-footnote');
-    if (foot) {
-      foot.innerHTML = 'Use “Renew connection” to refresh OAuth consent whenever the bank requires re-authentication.';
-    }
-
-    const saveBtn = $('#intg-sheet-save');
-    if (saveBtn) {
-      saveBtn.style.display = '';
-      saveBtn.disabled = false;
-      saveBtn.textContent = 'Save connection';
-      saveBtn.onclick = handleIntegrationSave;
-    }
-  }
-
-  async function launchTruelayerConnection(bank, cardEl=null) {
-    const statusBox = $('#truelayer-status');
-    if (cardEl) {
-      cardEl.setAttribute('aria-disabled', 'true');
-      cardEl.style.transition = 'opacity .3s ease';
-      cardEl.style.opacity = '0.6';
-    }
-    if (statusBox) {
-      statusBox.innerHTML = `<div class="alert alert-info border border-info-subtle">Preparing the ${escapeHtml(bank.name)} consent flow…</div>`;
-    }
-
-    try {
-      const res = await Auth.fetch('/api/integrations/truelayer/launch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          institution: {
-            id: bank.id,
-            name: bank.name,
-            brandColor: bank.brandColor,
-            accentColor: bank.accentColor,
-            icon: bank.icon,
-            tagline: bank.tagline,
-            providerId: bank.providerId,
-            providers: bank.providers
-          },
-          providers: Array.isArray(bank.providers) ? bank.providers : []
-        })
-      });
-
-      let payload = {};
-      try { payload = await res.json(); } catch {}
-
-      if (!res.ok) {
-        let message = payload?.error || 'Unable to launch the connection.';
-        if (payload?.missingEnv?.length) {
-          message = `Add ${payload.missingEnv.map((v) => `\u201c${escapeHtml(v)}\u201d`).join(', ')} in Render to enable this flow.`;
-        }
-        throw new Error(message);
-      }
-
-      const redirectUrl = payload?.authUrl;
-      if (!redirectUrl) {
-        throw new Error('Missing authorization URL from TrueLayer.');
-      }
-
-      if (statusBox) {
-        const expiryText = payload?.expiresAt ? ` before ${new Date(payload.expiresAt).toLocaleTimeString()}` : '';
-        statusBox.innerHTML = `<div class="alert alert-success border border-success-subtle">Redirecting you to TrueLayer to complete the bank consent journey${escapeHtml(expiryText)}…</div>`;
-      }
-
-      const providerTokens = new Set(['uk-ob-all']);
-      if (Array.isArray(bank.providers)) {
-        bank.providers.forEach((token) => {
-          const clean = String(token || '').trim();
-          if (clean) providerTokens.add(clean);
-        });
-      }
-
-      let finalUrl = redirectUrl;
-      try {
-        const url = new URL(redirectUrl);
-        const params = new URLSearchParams(url.search);
-        params.set('providers', Array.from(providerTokens).join(' '));
-        url.search = params.toString();
-        finalUrl = url.toString().replace(/\+/g, '%20');
-      } catch (e) {
-        console.warn('Unable to normalise TrueLayer URL, falling back to provided value.', e);
-      }
-
-      setTimeout(() => {
-        window.location.href = finalUrl;
-      }, 600);
-    } catch (err) {
-      console.error('TrueLayer connection failed', err);
-      if (statusBox) {
-        statusBox.innerHTML = `<div class="alert alert-danger border border-danger-subtle">${escapeHtml(err.message || 'Connection failed.')}</div>`;
-      } else {
-        alert(err.message || 'Connection failed.');
-      }
-    } finally {
-      if (cardEl) {
-        cardEl.removeAttribute('aria-disabled');
-        cardEl.style.opacity = '';
-      }
-    }
-  }
-
-  function closeIntegrationSheet() {
-    const sheet = $('#integration-sheet');
-    if (!sheet || sheet.hidden) return;
-    sheet.classList.remove('open');
-    const saveBtn = $('#intg-sheet-save');
-    if (saveBtn) {
-      saveBtn.onclick = null;
-      saveBtn.style.display = '';
-      saveBtn.disabled = false;
-      saveBtn.textContent = 'Save changes';
-    }
-    setTimeout(() => { sheet.hidden = true; }, 220);
-    const statusBox = $('#truelayer-status');
-    if (statusBox) statusBox.innerHTML = '';
-    ACTIVE_INTEGRATION = null;
-    SHEET_MODE = 'edit';
-  }
-
-  async function handleIntegrationSave() {
-    if (!ACTIVE_INTEGRATION) return;
-    const mode = SHEET_MODE;
-    const nameEl = $('#intg-field-name');
-    const descEl = $('#intg-field-description');
-    const statusEl = $('#intg-field-status');
-    const notesEl = $('#intg-field-notes');
-
-    let label = ACTIVE_INTEGRATION.label || '';
-    if (mode === 'create') label = (nameEl?.value || '').trim();
-    else if (nameEl) label = nameEl.value.trim() || label;
-    if (!label) {
-      alert('Please provide a name for this integration.');
-      return;
-    }
-
-    const status = statusEl ? statusEl.value : (ACTIVE_INTEGRATION.status || 'not_connected');
-    const metadata = { ...(ACTIVE_INTEGRATION.metadata || {}) };
-    if (descEl) metadata.description = descEl.value.trim();
-    if (notesEl) metadata.notes = notesEl.value.trim();
-    if (isBankConnection(ACTIVE_INTEGRATION)) {
-      if (nameEl) metadata.nickname = nameEl.value.trim();
-      metadata.lastManagedAt = new Date().toISOString();
-    }
-
-    let key = ACTIVE_INTEGRATION.key;
-    if (!key || mode === 'create') {
-      key = slugify(label) || `integration-${Date.now()}`;
-    }
-
-    const saveBtn = $('#intg-sheet-save');
-    if (saveBtn) {
-      saveBtn.disabled = true;
-      saveBtn.textContent = mode === 'create' ? 'Creating…' : 'Saving…';
-    }
-
-    try {
-      await persistIntegration(key, status, label, metadata);
-      await loadIntegrations();
-      closeIntegrationSheet();
-    } catch (err) {
-      console.error('Integration save failed', err);
-      alert(err.message || 'Failed to save integration.');
-    } finally {
-      if (saveBtn) {
-        saveBtn.disabled = false;
-        saveBtn.textContent = mode === 'create' ? 'Create integration' : 'Save changes';
-      }
-    }
-  }
-
-  async function persistIntegration(key, status, label, metadata) {
-    const res = await Auth.fetch(`/api/integrations/${encodeURIComponent(key)}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status, label, metadata })
-    });
-    if (!res.ok) {
-      let message = 'Unable to save integration.';
-      try {
-        const err = await res.json();
-        if (err?.error) message = err.error;
-      } catch {
-        try {
-          const txt = await res.text();
-          if (txt) message = txt;
-        } catch {}
-      }
-      throw new Error(message || 'Unable to save integration.');
-    }
-    return res.json();
-  }
-
-  async function deleteIntegration(integration) {
-    if (!integration?.key) return;
-    const isBank = isBankConnection(integration);
-    const confirmMsg = integration.status === 'connected'
-      ? `Disconnect ${integration.label}?${isBank ? ' This will pause live syncing.' : ''}`
-      : `Remove ${integration.label}?`;
-    if (!window.confirm(confirmMsg)) return;
-    try {
-      const res = await Auth.fetch(`/api/integrations/${encodeURIComponent(integration.key)}`, { method: 'DELETE' });
-      if (!res.ok) {
-        let message = 'Unable to remove integration.';
-        try {
-          const err = await res.json();
-          if (err?.error) message = err.error;
-        } catch {}
-        throw new Error(message);
-      }
-      let payload = null;
-      try { payload = await res.json(); } catch {}
-      await loadIntegrations(payload);
-    } catch (err) {
-      console.error('Integration delete failed', err);
-      alert(err.message || 'Failed to delete integration.');
-    }
-  }
-
-  async function renewIntegration(integration) {
-    if (!integration?.key) return;
-    try {
-      const res = await Auth.fetch(`/api/integrations/${encodeURIComponent(integration.key)}/renew`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
-      });
-      if (!res.ok) {
-        let message = 'Unable to renew connection.';
-        try {
-          const err = await res.json();
-          if (err?.error) message = err.error;
-        } catch {}
-        throw new Error(message);
-      }
-      let payload = null;
-      try { payload = await res.json(); } catch {}
-      await loadIntegrations(payload);
-
-      const wrap = $('#integration-list');
-      if (wrap) {
-        const note = document.createElement('div');
-        note.className = 'alert alert-success border border-success-subtle small';
-        note.textContent = `${integration.label || 'Connection'} renewed — we will refresh data shortly.`;
-        wrap.prepend(note);
-        setTimeout(() => {
-          note.style.transition = 'opacity .3s ease';
-          note.style.opacity = '0';
-          setTimeout(() => note.remove(), 320);
-        }, 2400);
-      }
-    } catch (err) {
-      console.error('Integration renew failed', err);
-      alert(err.message || 'Failed to renew connection.');
-    }
-  }
-
-  async function loadIntegrations(prefetched=null) {
-    try {
-      let payload = prefetched;
-      if (!payload) {
-        const res = await Auth.fetch('/api/integrations?t=' + Date.now());
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        payload = await res.json();
-      }
-      INTEGRATION_CATALOG = (payload.catalog || []).map(normaliseCatalogItem);
-      INTEGRATIONS = mergeIntegrations(INTEGRATION_CATALOG, payload.integrations || []);
-      renderIntegrations();
-      handleIntegrationReturnNotice();
-    } catch (err) {
-      console.error('Failed to load integrations', err);
-      const summary = $('#integration-summary');
-      if (summary) summary.textContent = 'Unable to load integrations right now.';
-      $('#integration-list')?.classList.add('opacity-50');
-    }
-  }
-
-  function handleIntegrationReturnNotice() {
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const flag = params.get('integrations');
-      if (!flag || !flag.startsWith('truelayer')) {
-        showIntegrationFlash(null);
-        return;
-      }
-
-      if (flag === 'truelayer-success') {
-        const connectionKey = params.get('connection');
-        let label = 'Your bank';
-        if (connectionKey) {
-          const found = INTEGRATIONS.find((item) => item.key === connectionKey);
-          if (found?.label) label = found.label;
-        }
-        showIntegrationFlash('success', `${label} is now connected via TrueLayer. We will start syncing data shortly.`);
-      } else {
-        const reasonParam = params.get('reason');
-        let reason = 'The TrueLayer consent journey did not complete.';
-        if (reasonParam) {
-          try { reason = decodeURIComponent(reasonParam); } catch {}
-        }
-        showIntegrationFlash('error', reason.replace(/_/g, ' '));
-      }
-
-      params.delete('integrations');
-      params.delete('reason');
-      params.delete('connection');
-      const newQuery = params.toString();
-      const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash}`;
-      window.history.replaceState({}, '', newUrl);
-    } catch (err) {
-      console.warn('Integration flash handling failed', err);
-    }
-  }
-
-  function bindEditControls() {
-    const card = $('#profile-card');
-    const btnEdit = $('#btn-edit');
-    const btnSave = $('#btn-save');
-    const btnCancel = $('#btn-cancel');
-
-    const editableInputs = [
-      $('#f-first'),
-      $('#f-last'),
-      $('#f-username'),
-      $('#f-email'),
-    ];
-
-    const setEditing = (on) => {
-      card.classList.toggle('editing', !!on);
-      for (const el of editableInputs) {
-        if (on) el.removeAttribute('readonly');
-        else el.setAttribute('readonly', 'readonly');
-      }
-    };
-
-    btnEdit.addEventListener('click', () => setEditing(!card.classList.contains('editing')));
-    btnCancel.addEventListener('click', () => {
-      setEditing(false);
-      // reset values
-      if (USER) {
-        $('#f-first').value = USER.firstName || '';
-        $('#f-last').value = USER.lastName || '';
-        $('#f-username').value = USER.username || '';
-        $('#f-email').value = USER.email || '';
-      }
-    });
-
-    btnSave.addEventListener('click', async () => {
-      const data = {
-        firstName: $('#f-first').value.trim(),
-        lastName:  $('#f-last').value.trim(),
-        username:  $('#f-username').value.trim(),
-        email:     $('#f-email').value.trim(),
-      };
-      const msgBefore = btnSave.textContent;
-      btnSave.disabled = true;
-      btnSave.textContent = 'Saving…';
-      try {
-        const r = await Auth.fetch('/api/user/me', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data)
-        });
-        if (!r.ok) {
-          let m = 'Update failed';
-          try { const j = await r.json(); if (j?.error) m = j.error; } catch {}
-          alert(m);
-          return;
-        }
-        const updated = await r.json();
-        USER = updated;
-        setEditing(false);
-      } catch (e) {
-        console.error(e);
-        alert('Update failed.');
-      } finally {
-        btnSave.disabled = false;
-        btnSave.textContent = msgBefore;
-      }
-    });
+    setTileGrid(tiles);
   }
 
   function renderProfile() {
-    if (!USER) return;
-    $('#f-first').value = USER.firstName || '';
-    $('#f-last').value = USER.lastName || '';
-    $('#f-username').value = USER.username || '';
-    $('#f-email').value = USER.email || '';
-    $('#f-dob').value = USER.dateOfBirth ? isoToDate(USER.dateOfBirth) : '—';
-    // billing tier: prefer SUBSCRIPTION if present, else licenseTier
-    const planUi = (SUBSCRIPTION?.licenseTier || USER.licenseTier || 'free').toLowerCase();
-    const interval = (SUBSCRIPTION?.subscription?.interval || 'monthly').toLowerCase();
-    const planLabel = (planUi === 'premium' ? 'Professional' : cap(planUi));
-    $('#f-tier').value = planLabel + (planUi !== 'free' ? ` (${cap(interval)})` : '');
-    $('#f-eula-ver').value = USER.eulaVersion || '—';
-    $('#f-eula-at').value = USER.eulaAcceptedAt ? isoToNice(USER.eulaAcceptedAt) : '—';
-    $('#f-created').value = USER.createdAt ? isoToNice(USER.createdAt) : '—';
-    $('#f-updated').value = USER.updatedAt ? isoToNice(USER.updatedAt) : '—';
+    if (!state.user) return;
+    $('#f-first').value = state.user.firstName || '';
+    $('#f-last').value = state.user.lastName || '';
+    $('#f-username').value = state.user.username || '';
+    $('#f-email').value = state.user.email || '';
+    $('#f-dob').value = isoToDate(state.user.dateOfBirth);
 
-    // EULA + Terms sidebar header numbers
-    $('#eula-version').textContent = USER.eulaVersion || '—';
-    $('#eula-date').textContent = USER.eulaAcceptedAt ? isoToDate(USER.eulaAcceptedAt) : '—';
+    const planId = currentPlanId();
+    const plan = planFor(planId);
+    const uiPlanId = plan ? plan.id : (planId === 'premium' ? 'professional' : planId);
+    $('#f-tier').value = cap(uiPlanId || 'free');
+
+    $('#f-eula-ver').value = state.user.eulaVersion || '—';
+    $('#f-eula-at').value = isoToNice(state.user.eulaAcceptedAt);
+    $('#f-created').value = isoToNice(state.user.createdAt);
+    $('#f-updated').value = isoToNice(state.user.updatedAt);
+
+    $('#eula-version').textContent = state.user.eulaVersion || '—';
+    $('#eula-date').textContent = isoToDate(state.user.eulaAcceptedAt);
+
+    Auth.setBannerTitle('Profile');
+    const greeting = $('#greeting-name');
+    if (greeting && state.user.firstName) greeting.textContent = state.user.firstName;
   }
 
   function renderBilling() {
-    const planUi = (SUBSCRIPTION?.licenseTier || USER.licenseTier || 'free').toLowerCase();
-    const sub = SUBSCRIPTION?.subscription || null;
-    const interval = (sub?.interval || 'monthly').toLowerCase();
+    const summary = $('#sub-summary');
+    const priceEl = $('#sub-price');
+    const benefitList = $('#benefit-list');
+    const pmWrap = $('#pm-list');
 
-    const planIdForUi = (planUi === 'premium') ? 'professional' : planUi; // align to /plans ids
-    const def = PLANS.find(p => p.id === planIdForUi);
-    const price = def ? (interval === 'yearly' ? def.priceYearly : def.priceMonthly) : 0;
-    const currency = def?.currency || 'GBP';
+    benefitList.innerHTML = '';
+    pmWrap.innerHTML = '';
 
-    $('#sub-summary').textContent = `${cap(planIdForUi)} ${planIdForUi === 'free' ? '' : `(${cap(interval)})`}`.trim();
-    $('#sub-price').textContent = planIdForUi === 'free' ? '£0.00' : `${fmtMoney(price, currency)} / ${interval === 'yearly' ? 'yr' : 'mo'}`;
+    const planId = currentPlanId();
+    const plan = planFor(planId);
+    const uiPlanId = plan ? plan.id : (planId === 'premium' ? 'professional' : planId);
+    const interval = currentInterval();
+    const cadenceLabel = interval === 'yearly' ? 'Yearly' : 'Monthly';
 
-    // Benefits
-    const list = $('#benefit-list');
-    list.innerHTML = '';
-    for (const li of featureListFor(planIdForUi)) {
-      const el = document.createElement('li');
-      el.textContent = li;
-      list.appendChild(el);
+    summary.textContent = `${cap(uiPlanId || 'free')} plan`;
+    if (plan && uiPlanId !== 'free') {
+      const price = interval === 'yearly' ? plan.priceYearly : plan.priceMonthly;
+      priceEl.textContent = `${fmtMoney(price, plan.currency)} · ${cadenceLabel}`;
+    } else {
+      priceEl.textContent = '£0.00 · Free tier';
     }
 
-    // Payment methods
-    const pmWrap = $('#pm-list');
-    pmWrap.innerHTML = '';
-    if (!PAYMENT_METHODS.length) {
-      pmWrap.innerHTML = `<div class="small muted">No payment methods yet.</div>`;
+    const features = plan?.features || [];
+    if (features.length) {
+      features.forEach((feature) => {
+        const li = document.createElement('li');
+        li.textContent = feature;
+        benefitList.appendChild(li);
+      });
     } else {
-      for (const m of PAYMENT_METHODS) {
+      const li = document.createElement('li');
+      li.className = 'text-muted';
+      li.textContent = 'Upgrade to unlock full benefits.';
+      benefitList.appendChild(li);
+    }
+
+    if (!state.paymentMethods.length) {
+      pmWrap.innerHTML = '<div class="small muted">Add a card in Billing to enable upgrades.</div>';
+    } else {
+      state.paymentMethods.forEach((method) => {
         const div = document.createElement('div');
         div.className = 'method';
         div.innerHTML = `
           <div>
-            <strong>${m.brand || 'Card'}</strong>
-            <span class="text-muted"> •••• ${m.last4 || ''}</span>
-            <span class="text-muted"> · exp ${String(m.expMonth).padStart(2,'0')}/${m.expYear}</span>
+            <strong>${method.brand || 'Card'}</strong>
+            <span class="text-muted"> •••• ${method.last4 || ''}</span>
+            <span class="text-muted"> · exp ${String(method.expMonth).padStart(2, '0')}/${method.expYear}</span>
           </div>
-          ${m.isDefault ? '<span class="badge badge-default">Default</span>' : ''}
+          ${method.isDefault ? '<span class="badge badge-default">Default</span>' : ''}
         `;
         pmWrap.appendChild(div);
-      }
-    }
-  }
-
-  function computeStats() {
-    const planUi = (SUBSCRIPTION?.licenseTier || USER.licenseTier || 'free').toLowerCase();
-    const planIdForUi = (planUi === 'premium') ? 'professional' : planUi;
-    const interval = (SUBSCRIPTION?.subscription?.interval || 'monthly').toLowerCase();
-
-    const def = PLANS.find(p => p.id === planIdForUi);
-    const moneySaved = def ? moneySavedStat(planIdForUi, interval) : { text: '—', delta: null, dir: null };
-
-    const planLabel = `${cap(planIdForUi)}${planIdForUi !== 'free' ? ` · ${cap(interval)}` : ''}`;
-    const planCost = def
-      ? `${fmtMoney(interval === 'yearly' ? def.priceYearly : def.priceMonthly, def.currency)} / ${interval === 'yearly' ? 'yr' : 'mo'}`
-      : '—';
-
-    // placeholders where data is not yet wired
-    const reportsGenerated = '—'; // reserved for future stats
-    const netWorthChange = '—';   // reserved
-    const netWorthDelta = '+0.0%';
-    const daysOnPlatform = USER?.createdAt ? daysBetween(USER.createdAt, new Date()) : '—';
-
-    setTileGrid({
-      moneySavedText: moneySaved.text,
-      moneySavedDelta: moneySaved.delta,
-      moneySavedDeltaDir: moneySaved.dir,
-      reportsGenerated,
-      netWorthChange,
-      netWorthDelta,
-      daysOnPlatform,
-      planLabel,
-      planCost,
-      planCycle: cap(interval)
-    });
-  }
-
-  function formatPlaidBalance(acct) {
-    const balances = acct?.balances || {};
-    const currency = balances.isoCurrencyCode || balances.iso_currency_code || acct?.currency || 'GBP';
-    const amount = balances.current ?? balances.available ?? null;
-    if (amount === null || typeof amount === 'undefined') return '—';
-    return fmtMoney(Number(amount), currency);
-  }
-
-  function deriveConnectionStatus(item) {
-    const statusRaw = (item?.status && typeof item.status === 'string') ? item.status
-      : (typeof item?.status?.code === 'string' ? item.status.code
-      : (item?.connectionStatus || item?.status?.stage || item?.health));
-    const status = String(statusRaw || '').toLowerCase();
-    const lastError = item?.status?.lastError || item?.lastError || null;
-
-    if (!status) return { label: 'Unknown', tone: 'muted', detail: lastError?.message || '' };
-    if (['healthy', 'ok', 'active'].includes(status)) {
-      return { label: 'Healthy', tone: 'ok', detail: '' };
-    }
-    if (['needs_reconnect', 'requires_reconnect', 'requires_login', 'login_required', 'reauth'].includes(status)) {
-      return { label: 'Action required', tone: 'warn', detail: lastError?.message || 'Reconnect via Plaid Link.' };
-    }
-    if (['error', 'disconnected', 'blocked'].includes(status)) {
-      return { label: 'Disconnected', tone: 'bad', detail: lastError?.message || '' };
-    }
-    if (['pending', 'connecting', 'creating', 'processing'].includes(status)) {
-      return { label: cap(status), tone: 'muted', detail: '' };
-    }
-    return { label: cap(status), tone: 'muted', detail: lastError?.message || '' };
-  }
-
-  function renderPlaidConnections() {
-    const list = $('#plaid-connection-list');
-    const empty = $('#plaid-empty');
-    if (!list || !empty) return;
-
-    list.innerHTML = '';
-    if (!PLAID_ITEMS.length) {
-      empty.hidden = false;
-      return;
-    }
-
-    empty.hidden = true;
-    for (const item of PLAID_ITEMS) {
-      const accounts = Array.isArray(item?.accounts) ? item.accounts : [];
-      const institution = item?.institution || {};
-      const instName = institution.name || item?.institutionName || 'Institution';
-      const logo = institution.logo || item?.institutionLogo || '';
-      const shortName = instName.slice(0, 2).toUpperCase();
-      const status = deriveConnectionStatus(item);
-      const lastSync = item?.lastSyncedAt || item?.lastSyncAt || item?.syncedAt || item?.updatedAt;
-      const linkedAt = item?.createdAt || item?.linkedAt;
-      const connectedUntil = item?.connectedUntil || item?.consentExpirationTime;
-
-      const accountsHtml = accounts.length
-        ? accounts.map(ac => {
-            const mask = ac?.mask || ac?.accountMask || ac?.last4 || '';
-            const maskDisplay = mask ? `•••• ${String(mask).slice(-4)}` : '••••';
-            const subtype = ac?.subtype || ac?.accountSubtype || ac?.type || '';
-            const name = ac?.name || ac?.officialName || ac?.accountName || subtype || 'Account';
-            const balance = formatPlaidBalance(ac);
-            const available = ac?.balances?.available ?? ac?.balances?.availableBalance;
-            const availableText = (available !== null && typeof available !== 'undefined' && available !== '')
-              ? ` · Avail ${fmtMoney(Number(available), ac?.balances?.isoCurrencyCode || ac?.balances?.iso_currency_code || ac?.currency || 'GBP')}`
-              : '';
-            const subtypeText = subtype ? ` · ${escapeHtml(cap(subtype))}` : '';
-            return `<li class="account-line">
-              <div><strong>${escapeHtml(name)}</strong> <span class="mask">${escapeHtml(maskDisplay)}</span>${subtypeText}</div>
-              <div>${balance}${availableText}</div>
-            </li>`;
-          }).join('')
-        : '<li class="account-line"><span class="text-muted">No accounts returned yet.</span></li>';
-
-      const metaParts = [];
-      if (linkedAt) {
-        const nice = isoToNice(linkedAt);
-        if (nice && nice !== '—') metaParts.push(`Linked ${nice}`);
-      }
-      if (lastSync) {
-        const nice = isoToNice(lastSync);
-        if (nice && nice !== '—') metaParts.push(`Last sync ${nice}`);
-      }
-      if (item?.status?.description) metaParts.push(escapeHtml(item.status.description));
-      if (status.detail) metaParts.push(escapeHtml(status.detail));
-      const expiryBadge = connectedUntil
-        ? `<div class="connection-expiry">Connected until ${escapeHtml(isoToNice(connectedUntil))}</div>`
-        : '';
-
-      const tile = document.createElement('div');
-      tile.className = 'connection-tile';
-      tile.dataset.connectionId = item?.id || item?.itemId || item?.plaidItemId || '';
-      tile.innerHTML = `
-        <div class="connection-head">
-          <div class="connection-bank">
-            ${logo ? `<img src="${logo}" alt="${escapeHtml(instName)} logo" loading="lazy">` : `<div class="logo-fallback">${escapeHtml(shortName)}</div>`}
-            <div>
-              <div class="fw-semibold">${escapeHtml(instName)}</div>
-              <div class="connection-meta">${metaParts.join(' · ')}</div>
-            </div>
-          </div>
-          <div class="connection-actions">
-            <span class="badge-status ${status.tone}">${escapeHtml(status.label)}</span>
-            ${expiryBadge}
-            <button class="btn btn-outline-primary btn-sm" type="button" data-action="renew">Renew</button>
-            <button class="btn btn-outline-danger btn-sm" type="button" data-action="delete">Remove</button>
-          </div>
-        </div>
-        <ul class="account-list">${accountsHtml}</ul>
-      `;
-
-      list.appendChild(tile);
-    }
-  }
-
-  async function refreshPlaidConnections({ silent=false } = {}) {
-    const list = $('#plaid-connection-list');
-    if (!list) return;
-    if (!silent) list.dataset.loading = 'true';
-    try {
-      const res = await Auth.fetch('/api/plaid/items?t=' + Date.now(), { cache: 'no-store' });
-      if (!res.ok) throw new Error('Failed to load Plaid items');
-      const payload = await res.json();
-      PLAID_ITEMS = Array.isArray(payload?.items) ? payload.items : (Array.isArray(payload) ? payload : []);
-    } catch (err) {
-      console.error('Failed to load Plaid connections', err);
-      PLAID_ITEMS = [];
-    } finally {
-      if (list.dataset.loading) delete list.dataset.loading;
-      renderPlaidConnections();
-    }
-  }
-
-  function ensurePlaidScript() {
-    if (window.Plaid) return Promise.resolve(window.Plaid);
-    if (PLAID_SCRIPT_PROMISE) return PLAID_SCRIPT_PROMISE;
-    PLAID_SCRIPT_PROMISE = new Promise((resolve, reject) => {
-      const existing = document.querySelector('script[data-plaid-link-script]');
-      if (existing) {
-        existing.addEventListener('load', () => resolve(window.Plaid));
-        existing.addEventListener('error', () => reject(new Error('Plaid Link failed to load.')));
-        return;
-      }
-      const script = document.createElement('script');
-      script.src = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
-      script.async = true;
-      script.dataset.plaidLinkScript = 'true';
-      script.onload = () => {
-        if (window.Plaid) resolve(window.Plaid);
-        else reject(new Error('Plaid Link unavailable after load.'));
-      };
-      script.onerror = () => reject(new Error('Plaid Link script failed to load.'));
-      document.head.appendChild(script);
-    });
-    return PLAID_SCRIPT_PROMISE;
-  }
-
-  async function handlePlaidLinkSuccess({ publicToken, metadata, mode, itemId }) {
-    try {
-      const res = await Auth.fetch('/api/plaid/link/exchange', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ publicToken, metadata, mode, itemId })
       });
-      if (!res.ok) {
-        let errText = 'Unable to save Plaid connection.';
-        try {
-          const errJson = await res.json();
-          if (errJson?.error) errText = errJson.error;
-        } catch {}
-        throw new Error(errText);
-      }
-      await refreshPlaidConnections({ silent: true });
-    } catch (err) {
-      console.error('Plaid exchange failed', err);
-      alert(err.message || 'Plaid connection failed.');
     }
   }
 
-  async function launchPlaidLink({ mode = 'create', itemId = null, button = null } = {}) {
-    const btn = button;
-    const resetBtn = () => {
-      if (!btn) return;
-      btn.disabled = false;
-      if (btn.dataset.origLabel) btn.textContent = btn.dataset.origLabel;
+  function toggleEditing(enabled) {
+    const card = $('#profile-card');
+    card?.classList.toggle('editing', enabled);
+    $$('.profile-fields [data-editable="true"] input').forEach((input, idx) => {
+      input.readOnly = !enabled;
+      input.classList.toggle('is-editing', enabled);
+      if (enabled && idx === 0) {
+        setTimeout(() => input.focus(), 20);
+      }
+    });
+    if (!enabled) showStatus('');
+  }
+
+  function gatherProfileForm() {
+    return {
+      firstName: ($('#f-first').value || '').trim(),
+      lastName: ($('#f-last').value || '').trim(),
+      username: ($('#f-username').value || '').trim(),
+      email: ($('#f-email').value || '').trim()
     };
+  }
+
+  function validateProfileForm(form) {
+    if (!form.firstName || !form.lastName || !form.email) {
+      throw new Error('First name, last name and email are required.');
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
+      throw new Error('Please enter a valid email address.');
+    }
+  }
+
+  async function saveProfile() {
+    const btn = $('#btn-save');
+    const cancelBtn = $('#btn-cancel');
+    const payload = gatherProfileForm();
 
     try {
-      if (btn) {
-        btn.dataset.origLabel = btn.textContent;
-        btn.disabled = true;
-        btn.textContent = mode === 'update' ? 'Opening…' : 'Connecting…';
-      }
-      const plaid = await ensurePlaidScript();
-      const res = await Auth.fetch('/api/plaid/link/launch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode, itemId })
-      });
-      if (!res.ok) throw new Error('Unable to get Plaid link token.');
-      const payload = await res.json();
-      const token = payload?.token || payload?.link_token;
-      if (!token) throw new Error('Plaid token missing.');
-
-      const handler = plaid.create({
-        token,
-        onSuccess: async (public_token, metadata) => {
-          await handlePlaidLinkSuccess({ publicToken: public_token, metadata, mode, itemId });
-        },
-        onExit: (err, metadata) => {
-          if (err) console.warn('Plaid Link exited with error', err, metadata);
-        }
-      });
-      handler.open();
+      validateProfileForm(payload);
     } catch (err) {
-      console.error('Plaid Link launch failed', err);
-      alert(err.message || 'Unable to open Plaid Link.');
-    } finally {
-      resetBtn();
-    }
-  }
-
-  function setupPlaidIntegration() {
-    if (PLAID_BINDINGS_READY) return;
-    PLAID_BINDINGS_READY = true;
-
-    const connectBtn = $('#btn-connect-plaid');
-    if (connectBtn) {
-      connectBtn.addEventListener('click', () => launchPlaidLink({ mode: 'create', button: connectBtn }));
+      showStatus(err.message, 'warning');
+      throw err;
     }
 
-    const refreshBtn = $('#btn-refresh-plaid');
-    if (refreshBtn) {
-      refreshBtn.addEventListener('click', async () => {
-        const orig = refreshBtn.textContent;
-        refreshBtn.disabled = true;
-        refreshBtn.textContent = 'Refreshing…';
-        try {
-          await refreshPlaidConnections();
-        } finally {
-          refreshBtn.disabled = false;
-          refreshBtn.textContent = orig;
-        }
-      });
-    }
-
-    const list = $('#plaid-connection-list');
-    if (list) {
-      list.addEventListener('click', (ev) => {
-        const btn = ev.target.closest('[data-action]');
-        if (!btn) return;
-        const tile = btn.closest('[data-connection-id]');
-        if (!tile) return;
-        const id = tile.dataset.connectionId;
-        const action = btn.dataset.action;
-        if (!id) {
-          alert('Missing connection identifier.');
-          return;
-        }
-        if (action === 'renew') {
-          launchPlaidLink({ mode: 'update', itemId: id, button: btn });
-        } else if (action === 'delete') {
-          deletePlaidConnection(id, btn);
-        }
-      });
-    }
-
-    ensurePlaidScript().catch((err) => console.warn('Plaid script pre-load failed', err));
-  }
-
-  async function deletePlaidConnection(id, btn) {
-    if (!confirm('Remove this Plaid connection?')) return;
-    const orig = btn.textContent;
     btn.disabled = true;
-    btn.textContent = 'Removing…';
+    cancelBtn.disabled = true;
+    const originalLabel = btn.textContent;
+    btn.textContent = 'Saving…';
+    showStatus('Saving your changes…', 'info');
+
     try {
-      const res = await Auth.fetch(`/api/plaid/items/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      const res = await Auth.fetch('/api/user/me', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
       if (!res.ok) {
-        let msg = 'Failed to remove connection.';
+        let message = 'Unable to update profile.';
         try {
-          const j = await res.json();
-          if (j?.error) msg = j.error;
+          const err = await res.json();
+          if (err?.error) message = err.error;
         } catch {}
-        throw new Error(msg);
+        throw new Error(message);
       }
-      await refreshPlaidConnections({ silent: true });
+
+      const updated = await res.json();
+      state.user = updated;
+      cacheUser(updated);
+      renderProfile();
+      computeStats();
+      showStatus('Profile updated successfully.', 'success');
+      toggleEditing(false);
     } catch (err) {
-      console.error('Delete connection failed', err);
-      alert(err.message || 'Unable to remove connection.');
+      console.error('Profile save failed', err);
+      showStatus(err.message || 'Unable to update profile.', 'danger');
+      throw err;
     } finally {
       btn.disabled = false;
-      btn.textContent = orig;
+      cancelBtn.disabled = false;
+      btn.textContent = originalLabel;
     }
   }
 
-  function loadNotes() {
+  function bindProfileEditing() {
+    const editBtn = $('#btn-edit');
+    const cancelBtn = $('#btn-cancel');
+    const saveBtn = $('#btn-save');
+    if (!editBtn || !cancelBtn || !saveBtn) return;
+
+    editBtn.addEventListener('click', () => {
+      toggleEditing(true);
+      showStatus('Fields unlocked — remember to save when you are done.', 'info');
+    });
+
+    cancelBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      renderProfile();
+      toggleEditing(false);
+    });
+
+    saveBtn.addEventListener('click', async (event) => {
+      event.preventDefault();
+      try {
+        await saveProfile();
+      } catch {
+        // handled in saveProfile
+      }
+    });
+  }
+
+  function initNotes() {
+    const textarea = $('#notes-box');
+    const saveBtn = $('#btn-notes-save');
+    if (!textarea || !saveBtn) return;
+    const storageKey = 'profile_notes';
     try {
-      const k = 'profile_notes';
-      const val = localStorage.getItem(k);
-      if (val) $('#notes-box').value = val;
-      $('#btn-notes-save').addEventListener('click', () => {
-        localStorage.setItem(k, $('#notes-box').value);
-        const btn = $('#btn-notes-save');
-        const orig = btn.textContent;
-        btn.disabled = true; btn.textContent = 'Saved';
-        setTimeout(() => { btn.disabled = false; btn.textContent = orig; }, 900);
-      });
+      const stored = localStorage.getItem(storageKey);
+      if (stored) textarea.value = stored;
     } catch {}
+
+    saveBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      try { localStorage.setItem(storageKey, textarea.value); } catch {}
+      saveBtn.disabled = true;
+      const original = saveBtn.textContent;
+      saveBtn.textContent = 'Saved';
+      setTimeout(() => {
+        saveBtn.disabled = false;
+        saveBtn.textContent = original;
+      }, 1200);
+    });
+  }
+
+  async function refreshData() {
+    const [meRes, subscriptionRes, paymentRes, plansRes] = await Promise.all([
+      Auth.fetch('/api/user/me?t=' + Date.now(), { cache: 'no-store' }),
+      Auth.fetch('/api/billing/subscription?t=' + Date.now(), { cache: 'no-store' }),
+      Auth.fetch('/api/billing/payment-methods?t=' + Date.now(), { cache: 'no-store' }),
+      Auth.fetch('/api/billing/plans?t=' + Date.now(), { cache: 'no-store' })
+    ]);
+
+    if (meRes.status === 401) {
+      throw new Error('Authentication required');
+    }
+    if (!meRes.ok) {
+      const text = await meRes.text();
+      throw new Error(text || 'Unable to load profile');
+    }
+    state.user = await meRes.json();
+    cacheUser(state.user);
+
+    if (subscriptionRes.ok) {
+      state.subscription = await subscriptionRes.json();
+    } else {
+      state.subscription = { licenseTier: state.user.licenseTier || 'free', subscription: null };
+    }
+
+    if (paymentRes.ok) {
+      const payload = await paymentRes.json();
+      state.paymentMethods = Array.isArray(payload?.methods) ? payload.methods : [];
+    } else {
+      state.paymentMethods = [];
+    }
+
+    if (plansRes.ok) {
+      const payload = await plansRes.json();
+      state.plans = Array.isArray(payload?.plans) ? payload.plans : [];
+    } else {
+      state.plans = [];
+    }
   }
 
   async function init() {
     try {
-      await Auth.requireAuth();
-      Auth.setBannerTitle('Profile');
-      bindIntegrationEvents();
+      const { me } = await Auth.requireAuth();
+      state.user = me;
+      cacheUser(me);
+    } catch (err) {
+      console.error('Auth required', err);
+      return;
+    }
 
-      // parallel fetches
-      const [meRes, plansRes, subRes, pmRes, integrationsRes] = await Promise.all([
-        Auth.fetch('/api/user/me'),
-        Auth.fetch('/api/billing/plans?t=' + Date.now()),
-        Auth.fetch('/api/billing/subscription?t=' + Date.now()),
-        Auth.fetch('/api/billing/payment-methods?t=' + Date.now()),
-        Auth.fetch('/api/integrations?t=' + Date.now())
-      ]);
-
-      USER = meRes.ok ? await meRes.json() : null;
-      const plansPayload = plansRes.ok ? await plansRes.json() : { plans: [] };
-      PLANS = plansPayload.plans || [];
-      PLANS.forEach(p => { PLAN_BY_ID[p.id] = p; });
-      SUBSCRIPTION = subRes.ok ? await subRes.json() : null;
-      const pmPayload = pmRes.ok ? await pmRes.json() : { methods: [] };
-      PAYMENT_METHODS = pmPayload.methods || [];
-
-      const integrationsPayload = integrationsRes.ok ? await integrationsRes.json() : { catalog: [], integrations: [] };
-      await loadIntegrations(integrationsPayload);
-
+    try {
+      await refreshData();
       renderProfile();
       renderBilling();
       computeStats();
-      bindEditControls();
-      loadNotes();
-      setupPlaidIntegration();
-      await refreshPlaidConnections({ silent: true });
-    } catch (e) {
-      console.error('Profile init error:', e);
+      bindProfileEditing();
+      initNotes();
+    } catch (err) {
+      console.error('Profile initialisation failed', err);
+      showStatus(err.message || 'Unable to load your profile.', 'danger');
     }
   }
 
   document.addEventListener('DOMContentLoaded', init);
 })();
-  async function ensureTruelayerProviderCatalogue() {
-    if (TL_PROVIDER_CATALOG.length) return TL_PROVIDER_CATALOG;
-    if (TL_PROVIDER_PROMISE) return TL_PROVIDER_PROMISE;
-
-    TL_PROVIDER_LOADING = true;
-    TL_PROVIDER_ERROR = null;
-    TL_PROVIDER_PROMISE = Auth.fetch('/api/integrations/truelayer/providers')
-      .then(async (res) => {
-        let payload = {};
-        try { payload = await res.json(); } catch (_) {}
-        if (!res.ok) {
-          throw new Error(payload?.error || 'Unable to load provider directory.');
-        }
-        return Array.isArray(payload?.providers) ? payload.providers : [];
-      })
-      .then((list) => {
-        TL_PROVIDER_CATALOG = list;
-        return list;
-      })
-      .catch((err) => {
-        TL_PROVIDER_ERROR = err?.message || 'Unable to load provider directory.';
-        console.error('TrueLayer provider fetch failed', err);
-        return [];
-      })
-      .finally(() => {
-        TL_PROVIDER_LOADING = false;
-        TL_PROVIDER_PROMISE = null;
-      });
-
-    return TL_PROVIDER_PROMISE;
-  }
-
-  function providerToBank(provider) {
-    if (!provider) return null;
-    const slug = provider.slug || slugify(provider.displayName || provider.providerId || 'provider');
-    const name = provider.displayName || provider.providerId || 'TrueLayer provider';
-    const tagline = provider.releaseStage
-      ? `${cap(provider.releaseStage)} · TrueLayer partner`
-      : 'Direct TrueLayer connection';
-
-    return {
-      id: slug || provider.providerId || `provider-${Math.random().toString(36).slice(2,8)}`,
-      providerId: provider.providerId,
-      providers: Array.isArray(provider.providers) ? provider.providers : [],
-      name,
-      tagline,
-      icon: '🏦',
-      brandColor: null,
-      accentColor: null
-    };
-  }
-
-  async function populateTruelayerProviderPicker(focus=false) {
-    const wrap = $('#tl-provider-select-wrap');
-    if (!wrap) return;
-
-    wrap.innerHTML = '<div class="text-muted small">Loading TrueLayer providers…</div>';
-    const providers = await ensureTruelayerProviderCatalogue();
-
-    if (TL_PROVIDER_ERROR) {
-      wrap.innerHTML = `
-        <div class="alert alert-warning border border-warning-subtle">${escapeHtml(TL_PROVIDER_ERROR)}</div>
-        <button type="button" class="btn btn-outline-primary btn-sm" id="tl-provider-retry">Retry</button>
-      `;
-      const retry = $('#tl-provider-retry');
-      if (retry) {
-        retry.addEventListener('click', () => {
-          TL_PROVIDER_CATALOG = [];
-          TL_PROVIDER_ERROR = null;
-          populateTruelayerProviderPicker(focus);
-        });
-      }
-      return;
-    }
-
-    if (!providers.length) {
-      wrap.innerHTML = '<div class="alert alert-info border border-info-subtle">TrueLayer did not return any providers for your credentials.</div>';
-      return;
-    }
-
-    const ukProviders = providers.filter((provider) => {
-      const countries = Array.isArray(provider.countries) ? provider.countries : [];
-      if (!countries.length) return true;
-      return countries.some((code) => ['GB', 'UK', 'GBR', 'United Kingdom'].includes(String(code).toUpperCase()));
-    });
-
-    const options = ukProviders.length ? ukProviders : providers;
-
-    wrap.innerHTML = '';
-
-    const intro = document.createElement('div');
-    intro.className = 'text-muted small';
-    intro.textContent = 'All UK-supported TrueLayer institutions — tap to launch their secure consent flow.';
-    wrap.appendChild(intro);
-
-    const grid = document.createElement('div');
-    grid.className = 'tl-provider-grid';
-    wrap.appendChild(grid);
-
-    options.forEach((provider) => {
-      const bank = providerToBank(provider);
-      if (!bank) return;
-      const card = document.createElement('button');
-      card.type = 'button';
-      card.className = 'tl-provider-card';
-      card.dataset.providerId = provider.providerId;
-
-      const initials = bankInitials(bank.name);
-      const stageRaw = provider.releaseStage ? String(provider.releaseStage).replace(/_/g, ' ') : '';
-      const stageLabel = stageRaw ? `${cap(stageRaw)} release` : 'Live partner';
-      const coverage = (Array.isArray(provider.countries) && provider.countries.length)
-        ? `${provider.countries.map((code) => {
-            const upper = String(code || '').toUpperCase();
-            return upper === 'GB' ? 'UK' : upper;
-          }).join(', ')} coverage`
-        : 'UK coverage';
-
-      const logoHtml = provider.logo
-        ? `<img src="${escapeAttr(provider.logo)}" alt="${escapeAttr(bank.name)} logo">`
-        : `<span>${escapeHtml(initials)}</span>`;
-
-      card.innerHTML = `
-        <span class="tl-provider-logo">${logoHtml}</span>
-        <div class="tl-provider-info">
-          <span class="provider-name">${escapeHtml(bank.name)}</span>
-          <span class="provider-tagline">${escapeHtml(bank.tagline)}</span>
-          <div class="provider-meta">
-            <span>${escapeHtml(stageLabel)}</span>
-            <span>${escapeHtml(coverage)}</span>
-            <span class="provider-chip" data-chip>Connect</span>
-          </div>
-        </div>
-      `;
-
-      card.addEventListener('click', async () => {
-        if (card.getAttribute('aria-disabled') === 'true') return;
-        const selected = providerByProviderId(card.dataset.providerId);
-        if (!selected) {
-          alert('Provider not recognised.');
-          return;
-        }
-        const launchBank = providerToBank(selected);
-        if (!launchBank) {
-          alert('Unable to launch provider.');
-          return;
-        }
-        const chip = card.querySelector('[data-chip]');
-        const original = chip ? chip.textContent : 'Connect';
-        card.setAttribute('aria-disabled', 'true');
-        if (chip) chip.textContent = 'Launching…';
-        try {
-          await launchTruelayerConnection(launchBank);
-        } finally {
-          if (chip) chip.textContent = original;
-          card.removeAttribute('aria-disabled');
-        }
-      });
-
-      grid.appendChild(card);
-    });
-
-    const helper = document.createElement('div');
-    helper.className = 'form-text mt-2';
-    helper.textContent = 'Powered by the TrueLayer provider directory.';
-    wrap.appendChild(helper);
-
-    if (!grid.children.length) {
-      grid.innerHTML = '<div class="text-muted small">No eligible UK institutions were returned for your credentials.</div>';
-    }
-
-    if (focus) {
-      setTimeout(() => {
-        if (wrap.scrollIntoView) wrap.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }, 120);
-    }
-  }

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -7,517 +7,468 @@
   <script src="/js/head-include.js"></script>
 
   <style>
-    :root{
-      --tile-gap: 14px;
-      --tile-radius: 16px;
-      --tile-shadow: 0 10px 30px rgba(0,0,0,.06), 0 2px 8px rgba(0,0,0,.06);
-      --tile-bg: var(--bs-body-bg, #fff);
-      --muted: #6b7280;
+    :root {
+      --tile-gap: clamp(14px, 2vw, 22px);
+      --tile-radius: 18px;
+      --tile-shadow: 0 12px 32px rgba(15, 23, 42, 0.09);
+      --tile-bg: var(--bg-surface, #fff);
+      --muted: rgba(15, 23, 42, 0.58);
+      --border-soft: rgba(15, 23, 42, 0.08);
+      --brand: var(--brand, #00C2A8);
       --ok: #16a34a;
-      --warn: #ca8a04;
-      --bad: #dc2626;
-      --brand: var(--bs-primary, #6f42c1);
-      --chip-bg: rgba(111,66,193,.08);
-      --chip-fg: var(--brand);
+      --warn: #f59e0b;
+      --danger: #dc2626;
     }
 
-    body{ background: var(--bg-body, #0b0c10); color: var(--fg, #111) }
-
-    .hero{
-      position: relative;
-      padding: 18px 0 6px;
-    }
-    .hero-title{
-      display:flex; align-items:center; gap:.75rem;
-    }
-    .hero-title .eyebrow{
-      font-size:.78rem; color:var(--muted); letter-spacing:.08em; text-transform:uppercase
+    body {
+      background: var(--bg-body, #F6FAF9);
+      color: var(--fg, #0C1520);
     }
 
-    .tile-grid{
-      display:grid;
-      grid-template-columns: repeat(12, 1fr);
+    main.profile-shell {
+      margin-top: clamp(1.5rem, 3vw, 2.5rem);
+      margin-bottom: clamp(2rem, 4vw, 3.5rem);
+    }
+
+    .hero {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(0.75rem, 2vw, 1.5rem);
+      margin-bottom: clamp(1.75rem, 3vw, 2.5rem);
+    }
+
+    .hero-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .hero-header .eyebrow {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--muted);
+      margin-bottom: 0.35rem;
+    }
+
+    .hero-header h1 {
+      font-size: clamp(1.75rem, 2.6vw, 2.4rem);
+      margin: 0;
+    }
+
+    .tile-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: var(--tile-gap);
-      margin-top: 14px;
     }
-    @media (max-width: 1199.98px){ .tile-grid{ grid-template-columns: repeat(8, 1fr); } }
-    @media (max-width: 767.98px){ .tile-grid{ grid-template-columns: repeat(4, 1fr); } }
 
-    .tile{
-      grid-column: span 3;
+    .tile {
       background: var(--tile-bg);
       border-radius: var(--tile-radius);
       box-shadow: var(--tile-shadow);
-      padding: 16px;
-      transition: transform .2s ease, box-shadow .2s ease;
-      will-change: transform;
-      border: 1px solid rgba(0,0,0,.06);
+      border: 1px solid var(--border-soft);
+      padding: clamp(1rem, 2vw, 1.35rem);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      min-height: 120px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
     }
-    .tile:hover{ transform: translateY(-3px); box-shadow: 0 14px 34px rgba(0,0,0,.10), 0 4px 12px rgba(0,0,0,.06); }
-    .tile .k{ font-size: .78rem; color: var(--muted); margin-bottom: 6px; }
-    .tile .v{ font-size: 1.65rem; font-weight: 700; display:flex; align-items:baseline; gap:.5rem; }
-    .tile .delta{ font-size:.85rem; padding:.15rem .5rem; border-radius:999px; background:var(--chip-bg); color:var(--chip-fg) }
-    .delta.up{ color: var(--ok); background: rgba(22,163,74,.08) }
-    .delta.down{ color: var(--bad); background: rgba(220,38,38,.08) }
 
-    .card-elev{
-      border-radius: 18px;
-      border: 1px solid rgba(0,0,0,.06);
-      box-shadow: var(--tile-shadow);
-      overflow: clip;
+    .tile:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
     }
-    .section-hd{
-      display:flex; align-items:center; justify-content:space-between; gap:1rem; margin-bottom:.35rem;
-    }
-    .section-hd h5{ margin:0; }
-    .muted{ color: var(--muted); }
 
-    .profile-fields .form-control[readonly],
-    .profile-fields .form-select[readonly]{
-      background-color: rgba(0,0,0,.03);
-      border-color: rgba(0,0,0,.08);
+    .tile .k {
+      font-size: 0.8rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .tile .v {
+      font-size: clamp(1.45rem, 2.4vw, 1.9rem);
+      font-weight: 700;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0.5rem;
+    }
+
+    .tile .delta {
+      font-size: 0.8rem;
+      padding: 0.25rem 0.65rem;
+      border-radius: 999px;
+      background: rgba(0, 194, 168, 0.12);
+      color: var(--brand);
+    }
+
+    .tile .delta.up { background: rgba(22, 163, 74, 0.12); color: var(--ok); }
+    .tile .delta.down { background: rgba(220, 38, 38, 0.12); color: var(--danger); }
+    .tile .delta.info { background: rgba(15, 23, 42, 0.06); color: var(--muted); }
+
+    .layout-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: clamp(1.5rem, 3vw, 2.5rem);
+    }
+
+    @media (min-width: 992px) {
+      .layout-grid {
+        grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+        align-items: start;
+      }
+    }
+
+    .card-elev {
+      border-radius: 20px;
+      border: 1px solid var(--border-soft);
+      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+      overflow: hidden;
+      background: var(--tile-bg);
+    }
+
+    .section-hd {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-bottom: clamp(0.75rem, 1.5vw, 1.1rem);
+    }
+
+    .section-hd .eyebrow {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--muted);
+      margin-bottom: 0.3rem;
+    }
+
+    .section-hd h5 {
+      margin: 0;
+      font-weight: 600;
+    }
+
+    .profile-fields .row + .row {
+      margin-top: 0.75rem;
+    }
+
+    .profile-fields label {
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+
+    .profile-fields input.form-control[readonly] {
+      background: rgba(15, 23, 42, 0.03);
+      border-color: rgba(15, 23, 42, 0.08);
       color: inherit;
     }
-    .profile-fields .row+.row{ margin-top:.5rem }
 
-    .edit-actions{ display:none; gap:.5rem }
-    .editing .edit-actions{ display:flex }
-    .editing .profile-fields [data-editable="true"] input{ background:#fff !important }
-
-    .icon-btn{
-      display:inline-flex; align-items:center; justify-content:center;
-      width:36px; height:36px; border-radius:10px;
-      border:1px solid rgba(0,0,0,.08); background:#fff; cursor:pointer;
-      transition: transform .15s ease, box-shadow .15s ease;
-    }
-    .icon-btn:hover{ transform: translateY(-2px); box-shadow: 0 8px 18px rgba(0,0,0,.08) }
-    .icon-btn svg{ width:18px; height:18px }
-
-    .pm-card .method{
-      border: 1px dashed rgba(0,0,0,.1);
-      border-radius: 12px;
-      padding: 10px 12px;
-      display:flex; align-items:center; justify-content:space-between;
+    .profile-fields input.is-editing {
       background: #fff;
     }
-    .badge-default{ background: var(--chip-bg); color: var(--chip-fg); }
 
-    .benefit-list{ margin: 0; padding-left: 1.1rem; }
-    .benefit-list li{ margin: .25rem 0; }
-
-    .notes-box{
-      width:100%; min-height: 120px; resize: vertical;
-    }
-
-    .link-muted{ color: var(--muted); text-decoration: none; }
-    .link-muted:hover{ text-decoration: underline; }
-
-    .integration-card{
-      display:flex;
-      flex-direction:column;
-      gap:1rem;
-    }
-    .integration-header{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:1rem;
-      flex-wrap:wrap;
-    }
-    .integration-actions{ display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; }
-    .connection-grid{ display:flex; flex-direction:column; gap:12px; }
-    .connection-tile{
-      display:flex;
-      flex-direction:column;
-      gap:.75rem;
-      padding:16px;
-      border-radius:14px;
-      border:1px solid rgba(0,0,0,.08);
-      background: var(--tile-bg);
-      box-shadow: 0 6px 20px rgba(15,23,42,.06);
-    }
-    .connection-head{
-      display:flex;
-      align-items:flex-start;
-      justify-content:space-between;
-      gap:1rem;
-      flex-wrap:wrap;
-    }
-    .connection-bank{
-      display:flex;
-      align-items:center;
-      gap:.75rem;
-    }
-    .connection-bank img{
-      width:42px;
-      height:42px;
-      border-radius:12px;
-      object-fit:contain;
-      background:#fff;
-      border:1px solid rgba(0,0,0,.05);
-      padding:6px;
-    }
-    .connection-bank .logo-fallback{
-      width:42px;
-      height:42px;
-      border-radius:12px;
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      font-weight:600;
-      color:var(--brand);
-      background: rgba(79,70,229,.12);
-    }
-    .badge-status{
-      font-size:.75rem;
-      border-radius:999px;
-      padding:.15rem .6rem;
-      background:var(--chip-bg);
-      color:var(--chip-fg);
-    }
-    .badge-status.ok{ background: rgba(22,163,74,.12); color:#15803d; }
-    .badge-status.warn{ background: rgba(202,138,4,.12); color:#b45309; }
-    .badge-status.bad{ background: rgba(220,38,38,.12); color:#b91c1c; }
-    .badge-status.muted{ background: rgba(107,114,128,.12); color:#4b5563; }
-    .connection-meta{ font-size:.8rem; color:var(--muted); }
-    .connection-actions{ display:flex; align-items:center; gap:.4rem; flex-wrap:wrap; }
-    .connection-actions button{ font-size:.8rem; }
-    .connection-actions .connection-expiry{
-      font-size:.72rem;
-      color:var(--muted);
-      font-weight:500;
-      white-space:nowrap;
-    }
-    .account-list{ display:flex; flex-direction:column; gap:.35rem; margin:0; padding:0; list-style:none; }
-    .account-line{ display:flex; align-items:baseline; justify-content:space-between; gap:.5rem; font-size:.85rem; }
-    .account-line strong{ font-size:.9rem; }
-    .account-line span.mask{ font-family:'IBM Plex Mono', monospace; font-size:.75rem; color:var(--muted); }
-    .empty-connections{
-      border:1px dashed rgba(148,163,184,.6);
-      border-radius:14px;
-      padding:18px;
-      text-align:center;
-      color:var(--muted);
-      font-size:.9rem;
+    .icon-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 12px;
+      border: 1px solid var(--border-soft);
+      background: #fff;
+      transition: transform 0.18s ease, box-shadow 0.18s ease;
     }
 
-    /* subtle section separators inside cards */
-    .subtle-hr{ border:0; height:1px; background: linear-gradient(90deg, rgba(0,0,0,.06), rgba(0,0,0,.02), rgba(0,0,0,.06)); margin:.75rem 0; }
+    .icon-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+    }
 
-    /* integrations */
-    .integration-list{ display:flex; flex-direction:column; gap:16px; }
-    .integration-card{ 
-      display:flex;
-      flex-direction:column;
-      gap:10px;
-      border:1px solid rgba(0,0,0,.08);
-      border-radius:16px;
-      padding:16px;
-      background:rgba(255,255,255,0.96);
-      box-shadow:0 10px 24px rgba(15,23,42,0.08);
-      transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+    .edit-actions {
+      display: none;
+      gap: 0.75rem;
     }
-    .integration-card:hover{ transform:translateY(-2px); box-shadow:0 16px 32px rgba(15,23,42,0.12); }
-    .integration-card[data-status="connected"]{ border-color:rgba(22,163,74,.25); box-shadow:0 14px 32px rgba(22,163,74,.12); }
-    .integration-card[data-kind="connection"]{ border-style:dashed; border-color:rgba(99,102,241,.28); background:linear-gradient(145deg, rgba(99,102,241,.08), rgba(255,255,255,.95)); }
-    .integration-card[data-kind="connection"] .integration-card-header{ gap:16px; }
-    .integration-card-header{ display:flex; gap:12px; align-items:flex-start; }
-    .integration-status-dot{ width:14px; height:14px; border-radius:999px; margin-top:4px; flex-shrink:0; box-shadow:0 0 0 6px rgba(148,163,184,.18); }
-    .integration-status-dot.status-green{ background:#16a34a; box-shadow:0 0 0 6px rgba(22,163,74,.18); }
-    .integration-status-dot.status-amber{ background:#f59e0b; box-shadow:0 0 0 6px rgba(245,158,11,.18); }
-    .integration-status-dot.status-red{ background:#dc2626; box-shadow:0 0 0 6px rgba(220,38,38,.18); }
-    .integration-card h6{ margin:0; font-weight:600; }
-    .integration-card .meta{ font-size:.78rem; color:var(--muted); }
-    .integration-actions{ display:flex; flex-wrap:wrap; gap:8px; }
-    .integration-actions .btn{ border-radius:999px; padding:.35rem .85rem; }
-    .integration-actions .btn-link{ padding:0; }
-    .integration-card[data-kind="connection"] .integration-actions{ justify-content:flex-end; }
-    .integration-meta{ font-size:.78rem; color:var(--muted); display:flex; flex-wrap:wrap; gap:1rem; }
-    .integration-badge{ font-size:.72rem; border-radius:999px; padding:.1rem .5rem; background:rgba(99,102,241,.1); color:#4338ca; }
 
-    .integration-card[data-kind="connection"] .integration-meta{ justify-content:space-between; gap:.75rem; align-items:center; }
-    .integration-card[data-kind="connection"] .integration-meta .status-text{ font-weight:600; }
-    .connection-avatar{ width:42px; height:42px; border-radius:14px; display:flex; align-items:center; justify-content:center; color:#fff; font-weight:600; font-size:1.05rem; box-shadow:0 10px 20px rgba(15,23,42,.18); flex-shrink:0; }
-    .connection-badge{ font-size:.7rem; border-radius:999px; padding:.2rem .55rem; background:rgba(99,102,241,.14); color:#312e81; }
+    #profile-card.editing .edit-actions {
+      display: flex;
+    }
 
-    .tl-bank-grid{ display:grid; gap:14px; grid-template-columns:repeat(auto-fit, minmax(160px, 1fr)); }
-    .tl-bank-card{ position:relative; border-radius:18px; padding:16px; background:linear-gradient(145deg, rgba(15,23,42,.92), rgba(15,23,42,.75)); color:#f8fafc; overflow:hidden; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease; min-height:132px; }
-    .tl-bank-card::after{ content:''; position:absolute; inset:0; background:var(--bank-gradient, rgba(99,102,241,.35)); opacity:.55; mix-blend-mode:screen; transition:opacity .2s ease; }
-    .tl-bank-card:hover{ transform:translateY(-4px); box-shadow:0 18px 36px rgba(15,23,42,.28); }
-    .tl-bank-card:hover::after{ opacity:.75; }
-    .tl-bank-card .bank-name{ position:relative; font-weight:600; font-size:1.05rem; }
-    .tl-bank-card .bank-tagline{ position:relative; font-size:.8rem; opacity:.85; margin-top:.35rem; }
-    .tl-bank-card .bank-chip{ position:relative; display:inline-flex; align-items:center; gap:.35rem; font-size:.72rem; margin-top:1.1rem; padding:.25rem .65rem; border-radius:999px; background:rgba(15,23,42,.35); box-shadow:inset 0 0 0 1px rgba(248,250,252,.35); backdrop-filter:blur(2px); }
-    .tl-bank-card .bank-chip svg{ width:16px; height:16px; }
-    .tl-bank-card[aria-disabled="true"]{ cursor:not-allowed; opacity:.6; }
-    .tl-bank-card[aria-disabled="true"]::after{ opacity:.35; }
-    .tl-bank-card[aria-disabled="true"]:hover{ transform:none; box-shadow:none; }
+    .notes-box {
+      min-height: 140px;
+      resize: vertical;
+      border-radius: 16px;
+    }
 
-    .tl-provider-grid{
-      display:grid;
-      grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
-      gap:14px;
-      margin-top:16px;
+    .notes-box:focus {
+      border-color: var(--brand);
+      box-shadow: 0 0 0 3px rgba(0, 194, 168, 0.25);
     }
-    .tl-provider-card{
-      position:relative;
-      display:flex;
-      align-items:center;
-      gap:14px;
-      width:100%;
-      border-radius:18px;
-      padding:14px 16px;
-      border:1px solid rgba(148,163,184,.2);
-      background:linear-gradient(135deg, rgba(30,41,59,.92), rgba(15,23,42,.82));
-      color:#f8fafc;
-      cursor:pointer;
-      transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;
-    }
-    .tl-provider-card:hover{
-      transform:translateY(-3px);
-      box-shadow:0 18px 36px rgba(15,23,42,.28);
-      border-color:rgba(99,102,241,.4);
-    }
-    .tl-provider-card[aria-disabled="true"]{
-      cursor:not-allowed;
-      opacity:.6;
-      box-shadow:none;
-    }
-    .tl-provider-card .tl-provider-logo{
-      width:44px;
-      height:44px;
-      border-radius:14px;
-      overflow:hidden;
-      flex-shrink:0;
-      box-shadow:0 10px 20px rgba(15,23,42,.4);
-      background:rgba(255,255,255,.1);
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      font-weight:600;
-      font-size:1.05rem;
-      color:#e0e7ff;
-    }
-    .tl-provider-card .tl-provider-logo img{
-      width:100%;
-      height:100%;
-      object-fit:cover;
-    }
-    .tl-provider-card .tl-provider-info{
-      display:flex;
-      flex-direction:column;
-      gap:4px;
-    }
-    .tl-provider-card .provider-name{
-      font-weight:600;
-      font-size:1rem;
-    }
-    .tl-provider-card .provider-meta{
-      font-size:.78rem;
-      opacity:.8;
-      display:flex;
-      flex-wrap:wrap;
-      gap:.5rem;
-    }
-    .tl-provider-card .provider-tagline{
-      font-size:.78rem;
-      opacity:.7;
-    }
-    .tl-provider-card .provider-chip{
-      display:inline-flex;
-      align-items:center;
-      gap:.35rem;
-      font-size:.72rem;
-      padding:.2rem .55rem;
-      border-radius:999px;
-      background:rgba(15,23,42,.45);
-      box-shadow:inset 0 0 0 1px rgba(226,232,240,.18);
-    }
-    .tl-provider-card .provider-chip svg{ width:14px; height:14px; }
 
-    .tl-sheet-hero{ display:flex; flex-direction:column; gap:.6rem; }
-    .tl-sheet-hero .eyebrow{ font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:#a5b4fc; }
-    .tl-sheet-footnote{ font-size:.78rem; color:var(--muted); }
+    .muted {
+      color: var(--muted);
+    }
 
-    .integration-sheet{ position:fixed; inset:0; display:flex; align-items:flex-end; justify-content:center; padding:24px; background:rgba(15,23,42,.45); backdrop-filter: blur(6px); z-index:1080; opacity:0; visibility:hidden; transition:opacity .2s ease; }
-    .integration-sheet.open{ opacity:1; visibility:visible; }
-    .integration-sheet[hidden]{ display:none; }
-    .integration-sheet .sheet-panel{ width:min(680px, 96%); background:var(--tile-bg); border-radius:22px 22px 16px 16px; box-shadow:0 22px 44px rgba(15,23,42,.35); transform:translateY(32px); transition:transform .25s ease; padding:24px 28px; max-height:90vh; overflow-y:auto; }
-    .integration-sheet.open .sheet-panel{ transform:translateY(0); }
-    .sheet-header{ display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; }
-    .sheet-body{ margin-top:1.25rem; display:flex; flex-direction:column; gap:1rem; font-size:.95rem; }
-    .sheet-body .alert{ margin-bottom:0; }
-    .sheet-footer{ margin-top:1.5rem; display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap; }
-    .sheet-footer .btn{ min-width:120px; }
-    .sheet-footer-note{ font-size:.78rem; color:var(--muted); }
-    .env-list{ display:flex; flex-direction:column; gap:.35rem; padding-left:1.1rem; margin:0; }
-    .env-list li{ font-size:.85rem; }
-    .badge-coming-soon{ background:rgba(148,163,184,.18); color:#475569; border-radius:999px; padding:.1rem .55rem; font-size:.72rem; }
+    .subtle-hr {
+      border: 0;
+      height: 1px;
+      width: 100%;
+      background: linear-gradient(90deg, rgba(15, 23, 42, 0.08), rgba(15, 23, 42, 0.03), rgba(15, 23, 42, 0.08));
+      margin: 1.1rem 0;
+    }
+
+    .pm-card .method {
+      border: 1px dashed rgba(15, 23, 42, 0.12);
+      border-radius: 14px;
+      padding: 0.9rem 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: rgba(255, 255, 255, 0.92);
+    }
+
+    .benefit-list {
+      margin: 0;
+      padding-left: 1.2rem;
+    }
+
+    .benefit-list li {
+      margin: 0.3rem 0;
+    }
+
+    .badge-default {
+      background: rgba(0, 194, 168, 0.12);
+      color: var(--brand);
+      border-radius: 999px;
+      padding: 0.25rem 0.65rem;
+      font-size: 0.78rem;
+    }
+
+    #profile-status {
+      transition: opacity 0.2s ease;
+    }
+
+    .link-muted {
+      color: var(--muted);
+      text-decoration: none;
+    }
+
+    .link-muted:hover {
+      text-decoration: underline;
+      color: var(--fg);
+    }
+
+    @media (max-width: 767.98px) {
+      main.profile-shell {
+        padding-inline: 0.75rem;
+      }
+
+      .tile {
+        min-height: 110px;
+        padding: 1rem;
+      }
+
+      .section-hd {
+        gap: 0.75rem;
+      }
+
+      .profile-fields .row {
+        row-gap: 0.75rem;
+      }
+    }
+
+    @media (max-width: 575.98px) {
+      .hero-header h1 {
+        font-size: clamp(1.5rem, 6vw, 1.85rem);
+      }
+
+      .hero-header {
+        align-items: flex-start;
+      }
+
+      .icon-btn {
+        width: 44px;
+        height: 44px;
+      }
+
+      .tile-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      }
+    }
   </style>
 </head>
 <body>
-  <!-- navbar + sidebar -->
   <div id="topbar-container"></div>
   <div id="sidebar-container"></div>
 
-  <main class="container py-4">
-    <!-- HERO -->
+  <main class="profile-shell container">
     <section class="hero">
-      <div class="hero-title">
+      <div class="hero-header">
         <div>
           <div class="eyebrow">Account</div>
           <h1 class="page-title" data-page-title>Profile</h1>
         </div>
       </div>
-
-      <div class="tile-grid" id="stat-tiles">
-        <!-- Tiles are injected by profile.js -->
-      </div>
+      <div class="tile-grid" id="stat-tiles"></div>
     </section>
 
-    <!-- PROFILE + BILLING -->
-    <section class="mt-4">
-      <div class="row g-3">
-        <!-- Left: Profile -->
-        <div class="col-12 col-xl-7">
-          <div class="card card-elev" id="profile-card">
-            <div class="card-body">
-              <div class="section-hd">
-                <div>
-                  <h5>Profile</h5>
-                  <div class="muted small">View your details. Nothing is editable until you click the pencil.</div>
+    <section class="layout-grid">
+      <div class="primary-col">
+        <div class="card card-elev" id="profile-card">
+          <div class="card-body">
+            <div class="section-hd">
+              <div>
+                <div class="eyebrow">Identity</div>
+                <h5 class="mb-0">Profile</h5>
+              </div>
+              <button class="icon-btn" id="btn-edit" type="button" title="Edit profile">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+                </svg>
+              </button>
+            </div>
+
+            <div id="profile-status" class="alert d-none" role="status"></div>
+
+            <div class="profile-fields">
+              <div class="row g-3">
+                <div class="col-md-6" data-editable="true">
+                  <label class="form-label" for="f-first">First name</label>
+                  <input id="f-first" class="form-control" type="text" readonly>
                 </div>
-                <div class="d-flex align-items-center gap-2">
-                  <button class="icon-btn" id="btn-edit" title="Edit">
-                    <!-- pencil (inline SVG for portability) -->
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                      <path d="M12 20h9" />
-                      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
-                    </svg>
-                  </button>
+                <div class="col-md-6" data-editable="true">
+                  <label class="form-label" for="f-last">Last name</label>
+                  <input id="f-last" class="form-control" type="text" readonly>
                 </div>
               </div>
-
-              <div class="profile-fields">
-                <div class="row">
-                  <div class="col-md-6" data-editable="true"><label class="form-label">First name</label><input id="f-first" class="form-control" type="text" readonly></div>
-                  <div class="col-md-6" data-editable="true"><label class="form-label">Last name</label><input id="f-last"  class="form-control" type="text" readonly></div>
+              <div class="row g-3">
+                <div class="col-md-6" data-editable="true">
+                  <label class="form-label" for="f-username">Username</label>
+                  <input id="f-username" class="form-control" type="text" readonly>
                 </div>
-                <div class="row">
-                  <div class="col-md-6" data-editable="true"><label class="form-label">Username</label><input id="f-username" class="form-control" type="text" readonly></div>
-                  <div class="col-md-6" data-editable="true"><label class="form-label">Email</label><input id="f-email"    class="form-control" type="email" readonly></div>
+                <div class="col-md-6" data-editable="true">
+                  <label class="form-label" for="f-email">Email</label>
+                  <input id="f-email" class="form-control" type="email" readonly>
                 </div>
-                <div class="row">
-                  <div class="col-md-6"><label class="form-label">Date of Birth</label><input id="f-dob" class="form-control" type="text" readonly></div>
-                  <div class="col-md-6"><label class="form-label">Billing Tier</label><input id="f-tier" class="form-control" type="text" readonly></div>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label" for="f-dob">Date of birth</label>
+                  <input id="f-dob" class="form-control" type="text" readonly>
                 </div>
-                <div class="row">
-                  <div class="col-md-6"><label class="form-label">EULA Version</label><input id="f-eula-ver" class="form-control" type="text" readonly></div>
-                  <div class="col-md-6"><label class="form-label">EULA Accepted</label><input id="f-eula-at" class="form-control" type="text" readonly></div>
+                <div class="col-md-6">
+                  <label class="form-label" for="f-tier">Plan</label>
+                  <input id="f-tier" class="form-control" type="text" readonly>
                 </div>
-                <div class="row">
-                  <div class="col-md-6"><label class="form-label">Created</label><input id="f-created" class="form-control" type="text" readonly></div>
-                  <div class="col-md-6"><label class="form-label">Last Updated</label><input id="f-updated" class="form-control" type="text" readonly></div>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label" for="f-eula-ver">EULA version</label>
+                  <input id="f-eula-ver" class="form-control" type="text" readonly>
                 </div>
-
-                <div class="d-flex justify-content-end mt-3 edit-actions">
-                  <button id="btn-cancel" class="btn btn-outline-secondary">Cancel</button>
-                  <button id="btn-save"   class="btn btn-primary">Save</button>
+                <div class="col-md-6">
+                  <label class="form-label" for="f-eula-at">EULA accepted</label>
+                  <input id="f-eula-at" class="form-control" type="text" readonly>
+                </div>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label" for="f-created">Created</label>
+                  <input id="f-created" class="form-control" type="text" readonly>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label" for="f-updated">Last updated</label>
+                  <input id="f-updated" class="form-control" type="text" readonly>
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- Notes & Goals -->
-          <div class="card card-elev mt-3">
-            <div class="card-body">
-              <div class="section-hd">
-                <h5>Notes &amp; Goals</h5>
-                <small class="muted">Free-form space for reminders, ideas, and plans.</small>
-              </div>
-              <textarea id="notes-box" class="form-control notes-box" placeholder="Use me for general notes, goals, reminders or thoughts!"></textarea>
-              <div class="d-flex justify-content-end mt-2">
-                <button id="btn-notes-save" class="btn btn-outline-primary btn-sm">Save notes</button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Plaid integrations -->
-          <div class="card card-elev mt-3">
-            <div class="card-body integration-card">
-              <div class="integration-header">
-                <div>
-                  <h5 class="mb-0">Bank connections via Plaid</h5>
-                  <div class="small muted">Securely link bank and credit accounts powered by Plaid Link.</div>
-                </div>
-                <div class="integration-actions">
-                  <button id="btn-connect-plaid" class="btn btn-primary btn-sm" type="button">Connect with Plaid</button>
-                  <button id="btn-refresh-plaid" class="btn btn-outline-secondary btn-sm" type="button">Refresh</button>
-                </div>
-              </div>
-              <div id="plaid-empty" class="empty-connections" hidden>
-                No Plaid connections yet. Link an institution to start syncing balances into your dashboards.
-              </div>
-              <div id="plaid-connection-list" class="connection-grid"></div>
+            <div class="d-flex justify-content-end mt-3 edit-actions">
+              <button id="btn-cancel" class="btn btn-outline-secondary" type="button">Cancel</button>
+              <button id="btn-save" class="btn btn-primary" type="button">Save changes</button>
             </div>
           </div>
         </div>
 
-        <!-- Right: Billing -->
-        <div class="col-12 col-xl-5">
-          <div class="card card-elev">
-            <div class="card-body">
-              <div class="section-hd">
-                <h5>Billing</h5>
-                <a class="link-muted small" href="/billing.html">Manage in Billing →</a>
+        <div class="card card-elev mt-3">
+          <div class="card-body">
+            <div class="section-hd">
+              <div>
+                <div class="eyebrow">Personal workspace</div>
+                <h5 class="mb-0">Notes &amp; goals</h5>
               </div>
-
-              <div class="mb-2">
-                <div class="muted small">Current subscription</div>
-                <div id="sub-summary" class="fw-semibold">—</div>
-                <div id="sub-price"   class="small muted">—</div>
-              </div>
-
-              <hr class="subtle-hr" />
-
-              <div class="mb-2">
-                <div class="muted small">Benefits</div>
-                <ul id="benefit-list" class="benefit-list small"></ul>
-              </div>
-
-              <hr class="subtle-hr" />
-
-              <div class="pm-card">
-                <div class="d-flex align-items-center justify-content-between mb-2">
-                  <h6 class="mb-0">Payment methods</h6>
-                  <a class="link-muted small" href="/billing.html#pm">Add or change →</a>
-                </div>
-                <div id="pm-list" class="d-flex flex-column gap-2"></div>
-              </div>
+              <small class="muted">Keep reminders and plans in one place.</small>
+            </div>
+            <textarea id="notes-box" class="form-control notes-box" placeholder="Use this space for reminders, coaching notes or upcoming goals."></textarea>
+            <div class="d-flex justify-content-end mt-2">
+              <button id="btn-notes-save" class="btn btn-outline-primary btn-sm" type="button">Save notes</button>
             </div>
           </div>
+        </div>
+      </div>
 
-          <!-- End User Agreement -->
-          <div class="card card-elev mt-3">
-            <div class="card-body">
-              <div class="section-hd">
-                <h5>End User Agreement</h5>
+      <div class="secondary-col">
+        <div class="card card-elev">
+          <div class="card-body">
+            <div class="section-hd">
+              <div>
+                <div class="eyebrow">Subscription</div>
+                <h5 class="mb-0">Billing</h5>
               </div>
-              <div class="small">
-                <div>Version: <span id="eula-version">—</span></div>
-                <div>Accepted: <span id="eula-date">—</span></div>
+              <a class="link-muted small" href="/billing.html">Manage in Billing →</a>
+            </div>
+
+            <div class="mb-3">
+              <div class="muted small">Current subscription</div>
+              <div id="sub-summary" class="fw-semibold">—</div>
+              <div id="sub-price" class="small muted">—</div>
+            </div>
+
+            <hr class="subtle-hr" />
+
+            <div class="mb-3">
+              <div class="muted small">Benefits</div>
+              <ul id="benefit-list" class="benefit-list small mb-0"></ul>
+            </div>
+
+            <hr class="subtle-hr" />
+
+            <div class="pm-card">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <h6 class="mb-0">Payment methods</h6>
+                <a class="link-muted small" href="/billing.html#pm">Manage →</a>
               </div>
-              <div class="mt-2">
-                <a class="link-muted" href="/eula.html" target="_blank" rel="noopener">View EULA</a> ·
-                <a class="link-muted" href="/terms.html" target="_blank" rel="noopener">View Terms</a>
-              </div>
+              <div id="pm-list" class="d-flex flex-column gap-2"></div>
             </div>
           </div>
+        </div>
 
+        <div class="card card-elev mt-3">
+          <div class="card-body">
+            <div class="section-hd">
+              <div>
+                <div class="eyebrow">Legal</div>
+                <h5 class="mb-0">End User Agreement</h5>
+              </div>
+            </div>
+            <div class="small">
+              <div>Version: <span id="eula-version">—</span></div>
+              <div>Accepted: <span id="eula-date">—</span></div>
+            </div>
+            <div class="mt-3 d-flex flex-wrap gap-3 small">
+              <a class="link-muted" href="/eula.html" target="_blank" rel="noopener">View EULA</a>
+              <a class="link-muted" href="/terms.html" target="_blank" rel="noopener">View Terms</a>
+              <a class="link-muted" href="/legal.html" target="_blank" rel="noopener">Privacy &amp; legal hub</a>
+            </div>
+          </div>
         </div>
       </div>
     </section>
-
   </main>
 
   <script src="/js/nav.js"></script>
@@ -526,26 +477,5 @@
   <script>Auth.enforce();</script>
   <script src="/js/profile.js"></script>
   <script src="/js/mobile-sidebar.js"></script>
-
-  <div class="integration-sheet" id="integration-sheet" hidden>
-    <div class="sheet-panel">
-      <div class="sheet-header">
-        <div>
-          <h5 class="mb-1" id="intg-sheet-title">Integration</h5>
-          <div class="small text-muted" id="intg-sheet-sub">Manage connection</div>
-        </div>
-        <button class="btn btn-light btn-sm" type="button" data-close-sheet>Close</button>
-      </div>
-      <div class="sheet-body" id="intg-sheet-body"></div>
-      <div class="sheet-footer">
-        <div class="sheet-footer-note" id="intg-sheet-footnote"></div>
-        <div class="d-flex gap-2 ms-auto">
-          <button class="btn btn-outline-secondary" type="button" data-close-sheet>Cancel</button>
-          <button class="btn btn-primary" type="button" id="intg-sheet-save">Save changes</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- harden the `/api/user/me` pipeline by making PDF exports optional and re-exporting the real router for legacy paths
- tighten front-end auth handling and rebuild the profile experience without Plaid/TrueLayer while keeping user data editable
- refresh shared styling so layouts adapt cleanly to mobile and update the profile page with a new responsive design

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e2b146e7248321bc5f042f9574e01a