### PR TITLE
Add affordability modelling to wealth planning

### DIFF
--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -65,6 +65,29 @@ router.get('/dashboard', auth, async (req, res) => {
   const range = parseRange(req.query);
   const integrations = Array.isArray(user.integrations) ? user.integrations : [];
   const hasData = integrations.some((i) => i.status === 'connected');
+  const wealthPlan = user.wealthPlan || {};
+  const summary = wealthPlan.summary || {};
+  const assetAllocation = Array.isArray(summary.assetAllocation) ? summary.assetAllocation : [];
+  const liabilitySchedule = Array.isArray(summary.liabilitySchedule) ? summary.liabilitySchedule : [];
+  const affordability = summary.affordability || {};
+
+  const assetBreakdown = assetAllocation.map((item) => ({
+    key: item.key || item.label,
+    label: item.label || item.key,
+    value: Number(item.total || 0),
+    weight: item.weight || 0,
+    type: 'asset'
+  }));
+
+  const liabilityBreakdown = liabilitySchedule.map((item) => ({
+    key: item.id || item.name,
+    label: item.name || 'Liability',
+    value: Number(item.startingBalance || 0),
+    monthlyPayment: Number(item.monthlyPayment || 0),
+    payoffMonths: item.payoffMonths || null,
+    type: 'liability'
+  }));
+
   const payload = {
     range,
     preferences: user.preferences || {},
@@ -84,19 +107,39 @@ router.get('/dashboard', auth, async (req, res) => {
       }
     },
     financialPosture: {
-      netWorth: null,
-      breakdown: [],
-      liquidity: null,
-      trends: [],
-      savingsRate: null
+      netWorth: summary.netWorth ?? null,
+      breakdown: [...assetBreakdown, ...liabilityBreakdown],
+      liquidity: summary.cashReserves != null ? {
+        cash: Number(summary.cashReserves || 0),
+        runwayMonths: summary.runwayMonths ?? null
+      } : null,
+      trends: summary.projections?.yearly || [],
+      savingsRate: affordability.savingsRateCurrent ?? null,
+      affordability: {
+        freeCashflow: affordability.freeCashflow ?? null,
+        recommendedContribution: affordability.recommendedContribution ?? null,
+        recommendedSavingsRate: affordability.recommendedSavingsRate ?? null,
+        advisories: Array.isArray(affordability.advisories) ? affordability.advisories : []
+      }
     },
     salaryNavigator: user.salaryNavigator || {},
-    wealthPlan: user.wealthPlan || {},
+    wealthPlan,
     aiInsights: [],
     gating: {
       tier: user.licenseTier || 'free'
     }
   };
+
+  const advisories = Array.isArray(affordability.advisories) ? affordability.advisories.filter(Boolean) : [];
+  if (advisories.length) {
+    payload.aiInsights.push({
+      id: `affordability-${Date.now()}`,
+      type: 'affordability',
+      title: 'Affordability advisory',
+      body: advisories.join(' '),
+      createdAt: new Date()
+    });
+  }
 
   res.json(payload);
 });

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -4,6 +4,7 @@ const bcrypt = require('bcryptjs');
 const auth = require('../middleware/auth');
 const User = require('../models/User');
 const PaymentMethod = require('../models/PaymentMethod');
+const { computeWealth } = require('../services/wealth/engine');
 let PDFDocument = null;
 try {
   PDFDocument = require('pdfkit');
@@ -199,85 +200,6 @@ function normaliseContributions(c = {}) {
   return { monthly: Number(c.monthly || 0) };
 }
 
-function monthsBetween(start, end) {
-  const a = new Date(start);
-  const b = new Date(end);
-  if (!a || !b || Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return null;
-  return Math.max(0, Math.round((b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth())));
-}
-
-function computeWealth(plan) {
-  const assets = Array.isArray(plan.assets) ? plan.assets : [];
-  const liabilities = Array.isArray(plan.liabilities) ? plan.liabilities : [];
-  const goals = Array.isArray(plan.goals) ? plan.goals : [];
-  const contributions = plan.contributions || { monthly: 0 };
-  const assetsTotal = assets.reduce((sum, a) => sum + Number(a.value || 0), 0);
-  const liabilitiesTotal = liabilities.reduce((sum, l) => sum + Number(l.balance || 0), 0);
-  const netWorth = assetsTotal - liabilitiesTotal;
-  const denominator = assetsTotal + liabilitiesTotal;
-  const ratio = denominator > 0 ? ((assetsTotal - liabilitiesTotal) / denominator) : 0;
-  const strength = Math.max(0, Math.min(100, Math.round((ratio * 50) + 50)));
-  const cashTotal = assets.filter((a) => ['cash','savings'].includes(String(a.category || '').toLowerCase())).reduce((sum, a) => sum + Number(a.value || 0), 0);
-  const monthly = Math.max(0, Number(contributions.monthly || 0));
-  const runwayMonths = monthly > 0 ? Math.max(0, Math.round(cashTotal / monthly)) : (cashTotal > 0 ? 0 : 0);
-
-  const steps = [];
-  let cursor = 1;
-  liabilities.filter((l) => l.status !== 'closed').sort((a, b) => Number(b.rate || 0) - Number(a.rate || 0)).forEach((liab) => {
-    const payment = Math.max(Number(liab.minimumPayment || 0), monthly || Number(liab.minimumPayment || 0));
-    const months = payment > 0 ? Math.ceil(Number(liab.balance || 0) / payment) : null;
-    steps.push({
-      id: liab.id || randomUUID(),
-      type: 'debt',
-      title: `Clear ${liab.name}`,
-      summary: `Allocate £${Math.round(payment).toLocaleString()} per month towards ${liab.name} at ${Number(liab.rate || 0).toFixed(2)}%.`,
-      startMonth: cursor,
-      endMonth: months ? cursor + months - 1 : null
-    });
-    if (months) cursor += months;
-  });
-
-  const milestones = goals.map((goal) => {
-    const months = goal.targetDate ? monthsBetween(new Date(), goal.targetDate) || 12 : 12;
-    const monthlyNeed = months > 0 ? Math.round(Number(goal.targetAmount || 0) / months) : Number(goal.targetAmount || 0);
-    return {
-      id: goal.id || randomUUID(),
-      title: goal.name || 'Goal',
-      description: `Allocate £${monthlyNeed.toLocaleString()} per month to reach £${Number(goal.targetAmount || 0).toLocaleString()}.`,
-      date: goal.targetDate ? new Date(goal.targetDate) : null,
-      amount: Number(goal.targetAmount || 0),
-      monthlyContribution: monthlyNeed
-    };
-  });
-
-  if (monthly > 0) {
-    steps.push({
-      id: randomUUID(),
-      type: 'invest',
-      title: 'Automate monthly investing',
-      summary: `Invest the remaining £${monthly.toLocaleString()} per month into diversified accounts once high-interest debt clears.`,
-      startMonth: cursor,
-      endMonth: cursor + 12
-    });
-  }
-
-  return {
-    summary: {
-      assetsTotal,
-      liabilitiesTotal,
-      netWorth,
-      strength,
-      runwayMonths,
-      cashReserves: cashTotal,
-      lastComputed: new Date()
-    },
-    strategy: {
-      steps,
-      milestones
-    }
-  };
-}
-
 function decorateWealth(plan) {
   const data = normalisePlanForResponse(plan);
   if (!data.summary || !Object.keys(data.summary).length) {
@@ -306,6 +228,42 @@ function normalisePlanForResponse(plan) {
   merged.goals = Array.isArray(plain.goals) ? plain.goals : [];
   merged.contributions = plain.contributions || { monthly: 0 };
   merged.summary = plain.summary || {};
+  merged.summary.assetAllocation = Array.isArray(merged.summary.assetAllocation) ? merged.summary.assetAllocation : [];
+  merged.summary.liabilitySchedule = Array.isArray(merged.summary.liabilitySchedule)
+    ? merged.summary.liabilitySchedule.map((item) => ({
+      ...item,
+      payoffDate: item?.payoffDate ? new Date(item.payoffDate) : null,
+      schedule: Array.isArray(item?.schedule) ? item.schedule : []
+    }))
+    : [];
+  const projections = merged.summary.projections || {};
+  merged.summary.projections = {
+    horizonMonths: Number(projections.horizonMonths || 0),
+    monthly: Array.isArray(projections.monthly) ? projections.monthly : [],
+    yearly: Array.isArray(projections.yearly) ? projections.yearly : [],
+    assumptions: projections.assumptions || {}
+  };
+  const affordability = merged.summary.affordability || {};
+  const goalScenarios = Array.isArray(affordability.goalScenarios)
+    ? affordability.goalScenarios.map((scenario) => ({
+      ...scenario,
+      targetDate: scenario?.targetDate ? new Date(scenario.targetDate) : null
+    }))
+    : [];
+  merged.summary.affordability = {
+    ...affordability,
+    monthlyIncome: affordability.monthlyIncome != null ? Number(affordability.monthlyIncome) : null,
+    monthlySpend: affordability.monthlySpend != null ? Number(affordability.monthlySpend) : null,
+    monthlyContribution: affordability.monthlyContribution != null ? Number(affordability.monthlyContribution) : null,
+    debtService: affordability.debtService != null ? Number(affordability.debtService) : null,
+    freeCashflow: affordability.freeCashflow != null ? Number(affordability.freeCashflow) : null,
+    savingsRateCurrent: affordability.savingsRateCurrent != null ? Number(affordability.savingsRateCurrent) : null,
+    recommendedSavingsRate: affordability.recommendedSavingsRate != null ? Number(affordability.recommendedSavingsRate) : null,
+    recommendedContribution: affordability.recommendedContribution != null ? Number(affordability.recommendedContribution) : null,
+    safeMonthlySavings: affordability.safeMonthlySavings != null ? Number(affordability.safeMonthlySavings) : null,
+    goalScenarios,
+    advisories: Array.isArray(affordability.advisories) ? affordability.advisories : []
+  };
   merged.strategy = plain.strategy || { steps: [], milestones: [] };
   merged.lastComputed = plain.lastComputed || null;
   return merged;
@@ -645,6 +603,14 @@ router.get('/wealth-plan/export', auth, async (req, res) => {
     doc.text(`Assets: ${currency(plan.summary?.assetsTotal)}  Liabilities: ${currency(plan.summary?.liabilitiesTotal)}`);
     doc.text(`Financial strength: ${plan.summary?.strength ?? 0}/100`);
     doc.text(`Cash runway: ${plan.summary?.runwayMonths ?? 0} months`);
+    if (plan.summary?.affordability) {
+      const aff = plan.summary.affordability;
+      const rateLabel = aff.recommendedSavingsRate != null ? `${Math.round(aff.recommendedSavingsRate * 1000) / 10}%` : '—';
+      doc.text(`Recommended savings rate: ${rateLabel}`);
+      if (aff.freeCashflow != null) {
+        doc.text(`Free cashflow after contributions: ${currency(aff.freeCashflow)}/month`);
+      }
+    }
     doc.moveDown();
     doc.fontSize(14).text('Assets', { underline: true });
     if (Array.isArray(plan.assets) && plan.assets.length) {

--- a/backend/services/wealth/engine.js
+++ b/backend/services/wealth/engine.js
@@ -1,0 +1,449 @@
+const { randomUUID } = require('crypto');
+
+const CATEGORY_LABELS = {
+  cash: 'Cash & savings',
+  savings: 'Cash & savings',
+  investments: 'Investments',
+  property: 'Property',
+  pension: 'Pension',
+  business: 'Business',
+  other: 'Other'
+};
+
+const CATEGORY_GROWTH = {
+  cash: 0.01,
+  savings: 0.01,
+  investments: 0.05,
+  property: 0.03,
+  pension: 0.04,
+  business: 0.06,
+  other: 0.02
+};
+
+const DEFAULT_INFLATION = 0.025;
+const PROJECTION_HORIZON_MONTHS = 120;
+
+function round(value, digits = 2) {
+  const factor = Math.pow(10, digits);
+  return Math.round((Number(value) + Number.EPSILON) * factor) / factor;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function addMonths(base, count) {
+  const d = new Date(base.getTime());
+  d.setMonth(d.getMonth() + count);
+  return d;
+}
+
+function monthsBetween(start, end) {
+  const a = new Date(start);
+  const b = new Date(end);
+  if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return null;
+  return Math.max(0, Math.round((b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth())));
+}
+
+function firstPositive(...values) {
+  for (const value of values) {
+    if (value == null) continue;
+    const num = Number(value);
+    if (Number.isFinite(num) && num > 0) return num;
+  }
+  return null;
+}
+
+function computeAssetClasses(assets = []) {
+  const totals = new Map();
+  assets.forEach((asset) => {
+    const key = String(asset.category || 'other').toLowerCase();
+    const value = Number(asset.value || 0);
+    if (!Number.isFinite(value) || value <= 0) return;
+    const current = totals.get(key) || 0;
+    totals.set(key, current + value);
+  });
+  const overall = Array.from(totals.values()).reduce((sum, value) => sum + value, 0);
+  return Array.from(totals.entries()).map(([key, total]) => {
+    const label = CATEGORY_LABELS[key] || key.replace(/\b\w/g, (c) => c.toUpperCase());
+    const assumedGrowth = CATEGORY_GROWTH[key] ?? CATEGORY_GROWTH.other;
+    return {
+      key,
+      label,
+      total: round(total),
+      weight: overall > 0 ? round(total / overall, 4) : 0,
+      assumedGrowth
+    };
+  }).sort((a, b) => b.total - a.total);
+}
+
+function buildLiabilitySchedule(liability = {}, fallbackBudget = 0) {
+  const startingBalance = Math.max(0, Number(liability.balance || 0));
+  const annualRate = Math.max(0, Number(liability.rate || 0));
+  const monthlyRate = annualRate / 100 / 12;
+  const baseMinimum = Math.max(0, Number(liability.minimumPayment || 0));
+  let standardPayment = baseMinimum;
+
+  if (!standardPayment) {
+    if (monthlyRate > 0) {
+      const assumedTermMonths = 120;
+      const numerator = startingBalance * monthlyRate * Math.pow(1 + monthlyRate, assumedTermMonths);
+      const denominator = Math.pow(1 + monthlyRate, assumedTermMonths) - 1;
+      standardPayment = denominator !== 0 ? numerator / denominator : startingBalance / assumedTermMonths;
+    } else {
+      standardPayment = startingBalance / 120;
+    }
+  }
+
+  if (fallbackBudget > 0) {
+    const suggested = fallbackBudget * 0.25;
+    standardPayment = Math.max(standardPayment, suggested);
+  }
+
+  standardPayment = Math.max(standardPayment, startingBalance > 0 ? Math.max(25, startingBalance / 240) : 0);
+
+  const rows = [];
+  let remaining = startingBalance;
+  let month = 1;
+  let totalInterest = 0;
+  const horizon = 360;
+
+  while (remaining > 0 && month <= horizon) {
+    const interest = remaining * monthlyRate;
+    totalInterest += interest;
+    let payment = standardPayment;
+    let principal = payment - interest;
+
+    if (principal <= 0) {
+      // Interest-only scenario, break to avoid infinite loop
+      rows.push({
+        month,
+        payment: round(payment),
+        interest: round(interest),
+        principal: 0,
+        balance: round(remaining + interest)
+      });
+      remaining += interest;
+      break;
+    }
+
+    if (principal > remaining) {
+      principal = remaining;
+      payment = interest + principal;
+    }
+
+    remaining = Math.max(0, remaining - principal);
+
+    rows.push({
+      month,
+      payment: round(payment),
+      interest: round(interest),
+      principal: round(principal),
+      balance: round(remaining)
+    });
+
+    if (remaining <= 0.5) {
+      remaining = 0;
+      break;
+    }
+
+    month += 1;
+  }
+
+  const payoffMonths = remaining <= 0 ? rows.length : null;
+  const payoffDate = payoffMonths ? addMonths(new Date(), payoffMonths) : null;
+
+  return {
+    id: liability.id || randomUUID(),
+    name: liability.name || 'Liability',
+    rate: annualRate,
+    startingBalance: round(startingBalance),
+    monthlyPayment: round(standardPayment),
+    payoffMonths,
+    payoffDate,
+    totalInterest: round(totalInterest),
+    schedule: rows
+  };
+}
+
+function computeLiabilityBalances(schedules, horizon) {
+  const balances = new Array(horizon).fill(0);
+  schedules.forEach((schedule) => {
+    const monthToBalance = new Map();
+    schedule.schedule.forEach((entry) => {
+      monthToBalance.set(entry.month, entry.balance);
+    });
+    let carry = schedule.startingBalance;
+    for (let month = 1; month <= horizon; month += 1) {
+      if (monthToBalance.has(month)) {
+        carry = monthToBalance.get(month);
+      }
+      balances[month - 1] += carry;
+    }
+  });
+  return balances.map((value) => round(value));
+}
+
+function computeProjections(options) {
+  const {
+    assetsTotal,
+    assetClasses,
+    liabilitySchedules,
+    monthlyContribution,
+    inflationRate,
+    horizon
+  } = options;
+
+  const weightedReturn = assetClasses.length
+    ? assetClasses.reduce((sum, cls) => sum + (cls.total * cls.assumedGrowth), 0) / (assetsTotal || 1)
+    : 0.03;
+
+  const monthlyReturn = weightedReturn / 12;
+  const liabilityBalances = computeLiabilityBalances(liabilitySchedules, horizon);
+  const monthlyProjection = [];
+  let projectedAssets = assetsTotal;
+
+  for (let month = 1; month <= horizon; month += 1) {
+    projectedAssets = (projectedAssets + monthlyContribution) * (1 + monthlyReturn);
+    const liabilities = liabilityBalances[month - 1] || 0;
+    const netWorth = projectedAssets - liabilities;
+    const inflationFactor = Math.pow(1 + inflationRate, month / 12);
+    const realNetWorth = inflationFactor > 0 ? netWorth / inflationFactor : netWorth;
+    monthlyProjection.push({
+      month,
+      assets: round(projectedAssets),
+      liabilities: round(liabilities),
+      netWorth: round(netWorth),
+      realNetWorth: round(realNetWorth)
+    });
+  }
+
+  const yearlyProjection = [];
+  for (let year = 1; year <= Math.floor(horizon / 12); year += 1) {
+    const sample = monthlyProjection[year * 12 - 1];
+    if (sample) {
+      yearlyProjection.push({
+        year,
+        assets: sample.assets,
+        liabilities: sample.liabilities,
+        netWorth: sample.netWorth,
+        realNetWorth: sample.realNetWorth
+      });
+    }
+  }
+
+  return {
+    horizonMonths: horizon,
+    monthly: monthlyProjection,
+    yearly: yearlyProjection,
+    assumptions: {
+      annualReturn: round(weightedReturn, 4),
+      inflationRate: round(inflationRate, 4),
+      monthlyContribution: round(monthlyContribution, 2)
+    }
+  };
+}
+
+function computeStrategy(liabilities, goals, schedules, monthlyContribution, availableForGoals) {
+  const openLiabilities = liabilities.filter((item) => item.status !== 'closed');
+  const sortedLiabilities = openLiabilities
+    .slice()
+    .sort((a, b) => Number(b.rate || 0) - Number(a.rate || 0));
+
+  const scheduleMap = new Map();
+  schedules.forEach((schedule) => {
+    scheduleMap.set(schedule.id, schedule);
+  });
+
+  const steps = [];
+  let cursor = 1;
+  sortedLiabilities.forEach((liability) => {
+    const schedule = scheduleMap.get(liability.id) || buildLiabilitySchedule(liability, monthlyContribution);
+    const months = schedule.payoffMonths;
+    steps.push({
+      id: schedule.id,
+      type: 'debt',
+      title: `Clear ${liability.name}`,
+      summary: `Direct £${Math.round(schedule.monthlyPayment).toLocaleString()} per month towards ${liability.name} at ${Number(liability.rate || 0).toFixed(2)}% interest.`,
+      startMonth: cursor,
+      endMonth: months ? cursor + months - 1 : null
+    });
+    if (months) cursor += months;
+  });
+
+  if (monthlyContribution > 0) {
+    steps.push({
+      id: randomUUID(),
+      type: 'invest',
+      title: 'Automate monthly investing',
+      summary: `Invest £${Math.round(monthlyContribution).toLocaleString()} per month into diversified accounts once priority debts are cleared.`,
+      startMonth: cursor,
+      endMonth: cursor + 24
+    });
+  }
+
+  const milestones = goals.map((goal) => {
+    const targetAmount = Number(goal.targetAmount || 0);
+    const monthsToGoal = availableForGoals > 0 ? Math.ceil(targetAmount / availableForGoals) : null;
+    const recommendedDate = monthsToGoal ? addMonths(new Date(), monthsToGoal) : null;
+    const targetMonths = goal.targetDate ? monthsBetween(new Date(), goal.targetDate) : null;
+    return {
+      id: goal.id || randomUUID(),
+      title: goal.name || 'Goal',
+      description: monthsToGoal
+        ? `At £${Math.round(availableForGoals).toLocaleString()} per month you will reach £${Math.round(targetAmount).toLocaleString()} in approximately ${monthsToGoal} months.`
+        : 'Increase savings capacity to reach this objective.',
+      date: recommendedDate,
+      amount: targetAmount,
+      monthlyContribution: monthsToGoal ? Math.round(targetAmount / monthsToGoal) : null,
+      targetMonths
+    };
+  });
+
+  return { steps, milestones };
+}
+
+function computeWealth(plan = {}) {
+  const assets = Array.isArray(plan.assets) ? plan.assets : [];
+  const liabilities = Array.isArray(plan.liabilities) ? plan.liabilities : [];
+  const goals = Array.isArray(plan.goals) ? plan.goals : [];
+  const contributions = plan.contributions || { monthly: 0 };
+  const monthlyContribution = Math.max(0, Number(contributions.monthly || 0));
+  const inflationRate = plan.assumptions?.inflationRate != null
+    ? Math.max(0, Number(plan.assumptions.inflationRate))
+    : DEFAULT_INFLATION;
+
+  const assetsTotal = assets.reduce((sum, asset) => sum + Number(asset.value || 0), 0);
+  const liabilitiesTotal = liabilities.reduce((sum, liability) => sum + Number(liability.balance || 0), 0);
+  const netWorth = assetsTotal - liabilitiesTotal;
+  const denominator = assetsTotal + liabilitiesTotal;
+  const ratio = denominator > 0 ? (netWorth / denominator) : 0;
+  const strength = Math.max(0, Math.min(100, Math.round((ratio * 50) + 50)));
+  const cashTotal = assets
+    .filter((asset) => ['cash', 'savings'].includes(String(asset.category || '').toLowerCase()))
+    .reduce((sum, asset) => sum + Number(asset.value || 0), 0);
+
+  const assetClasses = computeAssetClasses(assets);
+  const schedules = liabilities
+    .filter((liability) => liability.status !== 'closed')
+    .map((liability) => buildLiabilitySchedule(liability, monthlyContribution));
+
+  const debtService = schedules.reduce((sum, schedule) => sum + Number(schedule.monthlyPayment || 0), 0);
+
+  const monthlyIncomeRaw = firstPositive(
+    plan.cashflow?.incomeMonthly,
+    plan.analytics?.incomeMonthly,
+    plan.analytics?.income?.monthly
+  );
+
+  const monthlySpendRaw = firstPositive(
+    plan.cashflow?.spendMonthly,
+    plan.analytics?.spendMonthly,
+    plan.analytics?.spend?.monthly
+  );
+
+  const estimatedIncome = monthlyIncomeRaw != null
+    ? monthlyIncomeRaw
+    : (monthlySpendRaw != null ? monthlySpendRaw + monthlyContribution + debtService : null);
+
+  const monthlyIncome = estimatedIncome != null ? round(estimatedIncome, 2) : null;
+
+  const monthlySpend = monthlySpendRaw != null
+    ? round(monthlySpendRaw, 2)
+    : (monthlyIncome != null ? round(Math.max(0, monthlyIncome - monthlyContribution - debtService), 2) : null);
+
+  const freeCashflow = (monthlyIncome != null && monthlySpend != null)
+    ? Math.max(0, monthlyIncome - monthlySpend - debtService - monthlyContribution)
+    : Math.max(0, monthlyContribution - debtService);
+
+  const savingsRateCurrent = monthlyIncome ? round(monthlyContribution / monthlyIncome, 3) : null;
+
+  const recommendedSavingsRate = (monthlyIncome != null && monthlySpend != null)
+    ? clamp((monthlyIncome - monthlySpend - debtService) / monthlyIncome, 0.1, 0.35)
+    : null;
+
+  const recommendedContribution = recommendedSavingsRate != null
+    ? Math.max(0, Math.round(recommendedSavingsRate * monthlyIncome))
+    : null;
+
+  const safeMonthlySavings = recommendedContribution != null
+    ? recommendedContribution
+    : Math.max(0, monthlyContribution + Math.max(0, freeCashflow));
+
+  const affordabilityNotes = [];
+  if (monthlyIncome != null && monthlySpend != null) {
+    const spendRatio = monthlyIncome > 0 ? monthlySpend / monthlyIncome : null;
+    if (spendRatio != null && spendRatio > 0.6) {
+      affordabilityNotes.push('Discretionary spending is above 60% of income; trim non-essentials to accelerate saving.');
+    }
+  }
+  if (debtService > 0 && monthlyIncome != null) {
+    const ratio = debtService / monthlyIncome;
+    if (ratio > 0.35) {
+      affordabilityNotes.push('Debt servicing exceeds 35% of monthly income. Consider refinancing or prioritising overpayments.');
+    }
+  }
+  if (freeCashflow <= 0.01) {
+    affordabilityNotes.push('Cashflow after contributions is tight. Revisit savings rates or reduce upcoming commitments.');
+  }
+
+  const availableForGoals = safeMonthlySavings;
+
+  const goalScenarios = goals.map((goal) => {
+    const amount = Number(goal.targetAmount || 0);
+    const recommendedMonths = availableForGoals > 0 ? Math.ceil(amount / availableForGoals) : null;
+    return {
+      id: goal.id || randomUUID(),
+      name: goal.name || 'Goal',
+      amount,
+      recommendedMonths,
+      targetDate: goal.targetDate ? new Date(goal.targetDate) : null
+    };
+  });
+
+  const runwayBaseline = monthlySpend != null && monthlySpend > 0 ? monthlySpend : monthlyContribution || 0;
+  const runwayMonths = runwayBaseline > 0 ? Math.max(0, Math.round(cashTotal / runwayBaseline)) : null;
+
+  const projections = computeProjections({
+    assetsTotal,
+    assetClasses,
+    liabilitySchedules: schedules,
+    monthlyContribution,
+    inflationRate,
+    horizon: PROJECTION_HORIZON_MONTHS
+  });
+
+  const strategy = computeStrategy(liabilities, goals, schedules, monthlyContribution, availableForGoals);
+
+  const summary = {
+    assetsTotal: round(assetsTotal),
+    liabilitiesTotal: round(liabilitiesTotal),
+    netWorth: round(netWorth),
+    strength,
+    runwayMonths,
+    cashReserves: round(cashTotal),
+    lastComputed: new Date(),
+    assetAllocation: assetClasses,
+    liabilitySchedule: schedules,
+    projections,
+    affordability: {
+      monthlyIncome,
+      monthlySpend,
+      monthlyContribution,
+      debtService: round(debtService, 2),
+      freeCashflow: round(freeCashflow, 2),
+      savingsRateCurrent,
+      recommendedSavingsRate: recommendedSavingsRate != null ? round(recommendedSavingsRate, 3) : null,
+      recommendedContribution,
+      safeMonthlySavings: round(safeMonthlySavings, 2),
+      goalScenarios,
+      advisories: affordabilityNotes
+    }
+  };
+
+  return { summary, strategy };
+}
+
+module.exports = {
+  computeWealth
+};

--- a/frontend/wealth-lab.html
+++ b/frontend/wealth-lab.html
@@ -31,6 +31,8 @@
               <div class="mt-3">
                 <label class="form-label" for="wealth-monthly">Monthly wealth contribution (£)</label>
                 <input type="number" class="form-control" id="wealth-monthly" min="0" step="50" placeholder="750">
+                <div class="small text-muted mt-2">Suggested savings rate: <span id="wealth-safe-rate">—</span> (<span id="wealth-recommended">—</span>/mo)</div>
+                <div class="small text-muted">Free cashflow after debt: <span id="wealth-free-cashflow">—</span></div>
               </div>
             </div>
             <div class="col-12 col-lg-4">
@@ -48,6 +50,72 @@
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <div class="card shadow-sm border-0" id="affordability-card">
+        <div class="card-body">
+          <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+            <div>
+              <h2 class="h5 mb-1">Affordability planner</h2>
+              <p class="text-muted small mb-0">Stress-test upcoming purchases or liabilities against your available cashflow.</p>
+            </div>
+          </div>
+          <div class="row g-4 align-items-stretch">
+            <div class="col-12 col-lg-6">
+              <form id="affordability-form" class="row g-3">
+                <div class="col-12 col-md-6">
+                  <label class="form-label" for="planner-goal-type">Scenario</label>
+                  <select id="planner-goal-type" class="form-select">
+                    <option value="purchase">New purchase</option>
+                    <option value="liability">New liability</option>
+                  </select>
+                </div>
+                <div class="col-12 col-md-6">
+                  <label class="form-label" for="planner-goal-amount">Total amount (£)</label>
+                  <input type="number" class="form-control" id="planner-goal-amount" min="0" step="100" placeholder="15000">
+                </div>
+                <div class="col-12 col-md-6">
+                  <label class="form-label" for="planner-goal-months">Target timeline (months)</label>
+                  <input type="number" class="form-control" id="planner-goal-months" min="1" step="1" placeholder="18">
+                </div>
+                <div class="col-12 col-md-6">
+                  <label class="form-label" for="planner-goal-start">Desired start date</label>
+                  <input type="date" class="form-control" id="planner-goal-start">
+                </div>
+                <div class="col-12">
+                  <div class="alert alert-light border mb-0" id="planner-summary">Enter a target amount to generate recommendations.</div>
+                  <div class="small mt-2" id="planner-outcome"></div>
+                </div>
+              </form>
+            </div>
+            <div class="col-12 col-lg-6">
+              <div class="border rounded p-3 h-100 bg-light">
+                <h6 class="fw-semibold mb-3">Cashflow snapshot</h6>
+                <dl class="row small mb-0">
+                  <dt class="col-7 text-muted">Monthly income</dt>
+                  <dd class="col-5 text-end" id="planner-income">—</dd>
+                  <dt class="col-7 text-muted">Core spend</dt>
+                  <dd class="col-5 text-end" id="planner-spend">—</dd>
+                  <dt class="col-7 text-muted">Debt service</dt>
+                  <dd class="col-5 text-end" id="planner-debt-service">—</dd>
+                  <dt class="col-7 text-muted">Free cashflow</dt>
+                  <dd class="col-5 text-end" id="planner-free-cashflow">—</dd>
+                  <dt class="col-7 text-muted">Safe savings rate</dt>
+                  <dd class="col-5 text-end" id="planner-safe-rate">—</dd>
+                  <dt class="col-7 text-muted">Safe monthly savings</dt>
+                  <dd class="col-5 text-end" id="planner-safe-monthly">—</dd>
+                </dl>
+                <div class="mt-3">
+                  <h6 class="fw-semibold mb-2">Existing goals</h6>
+                  <ul class="list-unstyled small mb-0" id="planner-goal-scenarios"></ul>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-3" id="planner-advisories"></div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a dedicated wealth engine service that models asset classes, amortisation schedules, projections, and affordability metrics
- update user and analytics routes to cache computed projections, surface asset/liability splits, and publish affordability advisories
- extend the wealth lab UI with an affordability planner card that recommends safe savings rates and goal timelines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e32a448e2483218c97799b4aa98725