### PR TITLE
Add HMRC tax lab experience with backend snapshot endpoints

### DIFF
--- a/backend/data/documentCatalogue.js
+++ b/backend/data/documentCatalogue.js
@@ -1,0 +1,35 @@
+// backend/data/documentCatalogue.js
+// Shared catalogue of required evidence documents for HMRC workflows.
+// This mirrors the required entries in the frontend catalogue so that
+// backend services can reason about evidence coverage without duplicating
+// the entire table rendering logic.
+
+const REQUIRED_DOCUMENTS = [
+  { key: 'proof_of_id',       label: 'Proof of ID',                                  cadence: { months: 60 } },
+  { key: 'proof_of_address',  label: 'Proof of Address',                             cadence: { months: 6 } },
+  { key: 'sa100_return_copy', label: 'SA100 Self Assessment (copy)',                 cadence: { yearlyBy: '01-31' } },
+  { key: 'sa302_tax_calc',    label: 'SA302 / Tax Calculation',                      cadence: { yearlyBy: '01-31' } },
+  { key: 'hmrc_statement',    label: 'HMRC Statement of Account',                    cadence: { yearlyBy: '01-31' } },
+  { key: 'p60',               label: 'P60 End of Year Certificate',                  cadence: { yearlyBy: '06-01' } },
+  { key: 'p11d',              label: 'P11D Benefits in Kind',                        cadence: { yearlyBy: '07-06' } },
+  { key: 'pension_statement', label: 'Pension Annual Statement (SIPP/Workplace)',    cadence: { yearlyBy: '06-30' } },
+  { key: 'pension_pia',       label: 'Pension Input Amounts (last 3 years)',         cadence: { yearlyBy: '06-30' } },
+  { key: 'interest_certs',    label: 'Bank/Building Society Interest Certificates',  cadence: { yearlyBy: '06-30' } },
+  { key: 'dividend_vouchers', label: 'Dividend Vouchers',                            cadence: { months: 12 } },
+  { key: 'broker_tax_pack',   label: 'Broker Annual Tax Pack / CTC',                 cadence: { yearlyBy: '06-30' } },
+  { key: 'trade_confirmations', label: 'Trade Confirmations / Contract Notes',       cadence: { months: 1 } },
+  { key: 'crypto_history',    label: 'Crypto Full Trade History (CSV/API)',          cadence: { months: 1 } },
+  { key: 'agent_statements',  label: 'Letting Agent Monthly Statements',             cadence: { months: 1 } },
+  { key: 'mortgage_interest', label: 'Annual Mortgage Interest Certificate',         cadence: { yearlyBy: '05-31' } },
+  { key: 'repairs_capital',   label: 'Repairs vs Capital Improvements Receipts',     cadence: { months: 1 } },
+  { key: 'purchase_completion', label: 'Purchase Completion Statement',              cadence: { adhoc: true } },
+  { key: 'sale_completion',   label: 'Sale Completion Statement',                    cadence: { adhoc: true } },
+  { key: 'sdlt_return',       label: 'SDLT Return & Calculation',                    cadence: { adhoc: true } },
+  { key: 'equity_grants',     label: 'RSU/ESPP/Option Grant Agreements & Schedules', cadence: { adhoc: true } },
+  { key: 'equity_events',     label: 'Vest/Exercise/Sell Confirmations',             cadence: { months: 1 } },
+  { key: 'gift_aid',          label: 'Gift Aid Donation Schedule & Receipts',        cadence: { months: 12 } },
+];
+
+module.exports = {
+  REQUIRED_DOCUMENTS,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -29,6 +29,7 @@ const billingRouter = safeRequire('./routes/billing')               || safeRequi
 const vaultRouter  = safeRequire('./routes/vault')                || safeRequire('./src/routes/vault');
 const integrationsRouter = safeRequire('./routes/integrations')     || safeRequire('./src/routes/integrations');
 const analyticsRouter = safeRequire('./routes/analytics')           || safeRequire('./src/routes/analytics');
+const taxRouter       = safeRequire('./routes/tax')                 || safeRequire('./src/routes/tax');
 const truelayerRouter  = safeRequire('./routes/truelayer')          || safeRequire('./src/routes/truelayer');
 
 // ---- AUTH GATE ----
@@ -84,6 +85,8 @@ mount('/api/billing', billingRouter, 'billing');
 mount('/api/ai', aiRouter, 'ai');
 mount('/api/vault', vaultRouter, 'vault');
 mount('/api/plaid', plaidRouter, 'plaid');
+mount('/api/analytics', analyticsRouter, 'analytics');
+mount('/api/tax', taxRouter, 'tax');
 
 
 

--- a/backend/routes/tax.js
+++ b/backend/routes/tax.js
@@ -1,0 +1,537 @@
+// backend/routes/tax.js
+// Aggregated tax analytics for the Tax Lab.
+
+const express = require('express');
+const dayjs = require('dayjs');
+
+const auth = require('../middleware/auth');
+const User = require('../models/User');
+const { REQUIRED_DOCUMENTS } = require('../data/documentCatalogue');
+const { readJsonSafe, paths } = require('../src/store/jsondb');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/snapshot', async (req, res) => {
+  const user = await User.findById(req.user.id).lean();
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const hmrc = findHmrcIntegration(user.integrations);
+  const meta = hmrc?.metadata || {};
+
+  const allowances = buildAllowances(meta, user);
+  const paymentsOnAccount = buildPayments(meta, allowances);
+  const obligations = buildObligations(meta, paymentsOnAccount);
+  const balances = buildBalances(meta, paymentsOnAccount);
+  const documents = await buildDocuments(req.user.id);
+  const aiPromptSeed = buildAiSeed({
+    hmrc,
+    user,
+    allowances,
+    paymentsOnAccount,
+    obligations,
+    balances,
+    documents,
+  });
+
+  res.json({
+    updatedAt: hmrc?.lastCheckedAt || meta.updatedAt || null,
+    integrations: {
+      hmrcConnected: hmrc?.status === 'connected',
+      lastSync: hmrc?.lastCheckedAt || null,
+    },
+    personalTaxCode: {
+      code: meta.taxCode || user.salaryNavigator?.taxSummary?.taxCode || '1257L',
+      source: meta.taxCode ? 'hmrc' : 'derived',
+      updatedAt: meta.taxCodeUpdatedAt || hmrc?.lastCheckedAt || null,
+    },
+    hmrcBalances: balances,
+    allowances,
+    paymentsOnAccount,
+    obligations,
+    documents,
+    aiPromptSeed,
+    quickActions: buildQuickActions({
+      allowances,
+      paymentsOnAccount,
+      obligations,
+      balances,
+    }),
+  });
+});
+
+router.get('/scenarios', async (req, res) => {
+  const user = await User.findById(req.user.id).lean();
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const hmrc = findHmrcIntegration(user.integrations);
+  const meta = hmrc?.metadata || {};
+  const allowances = buildAllowances(meta, user);
+  const paymentsOnAccount = buildPayments(meta, allowances);
+
+  res.json({
+    baseline: buildBaseline(meta, paymentsOnAccount),
+    deltas: buildScenarioDeltas(meta, allowances, paymentsOnAccount),
+  });
+});
+
+module.exports = router;
+
+// --------------------------- helpers ---------------------------
+
+function findHmrcIntegration(integrations) {
+  if (!Array.isArray(integrations)) return null;
+  return integrations.find((item) => (item?.key || '').toLowerCase() === 'hmrc') || null;
+}
+
+function toNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function pct(used, total) {
+  const t = toNumber(total, 0);
+  if (!t) return 0;
+  return Math.min(100, Math.round((toNumber(used, 0) / t) * 100));
+}
+
+function buildAllowances(meta, user) {
+  const sourceArray = Array.isArray(meta.allowances) ? meta.allowances : null;
+  const sourceObject = !sourceArray && meta.gauges && typeof meta.gauges === 'object' ? meta.gauges : null;
+  const navigator = user?.salaryNavigator?.taxSummary?.gauges || {};
+
+  const defaults = [
+    { key: 'personalAllowance', label: 'Personal allowance', total: 12570 },
+    { key: 'dividendAllowance', label: 'Dividend allowance', total: 500 },
+    { key: 'cgtAllowance', label: 'Capital gains annual exempt amount', total: 3000 },
+    { key: 'pensionAnnual', label: 'Pension annual allowance', total: 60000 },
+    { key: 'isa', label: 'ISA subscription limit', total: 20000 },
+  ];
+
+  const allowances = [];
+  if (sourceArray) {
+    sourceArray.forEach((item) => {
+      allowances.push(normaliseAllowance(item));
+    });
+  } else if (sourceObject) {
+    Object.entries(sourceObject).forEach(([key, value]) => {
+      allowances.push(normaliseAllowance({ key, label: prettifyKey(key), ...value }));
+    });
+  } else {
+    Object.entries(navigator).forEach(([key, value]) => {
+      allowances.push(normaliseAllowance({ key, label: prettifyKey(key), ...value }));
+    });
+  }
+
+  const knownKeys = new Set(allowances.map((a) => a.key));
+  defaults.forEach((item) => {
+    if (knownKeys.has(item.key)) return;
+    allowances.push(normaliseAllowance(item));
+  });
+
+  return allowances
+    .map((item) => {
+      const used = toNumber(item.used, 0);
+      const total = toNumber(item.total, 0);
+      const remaining = Math.max(0, total - used);
+      return {
+        key: item.key,
+        label: item.label,
+        used,
+        total,
+        remaining,
+        percentUsed: pct(used, total),
+        status: allowanceStatus(used, total),
+        updatedAt: item.updatedAt || meta.updatedAt || null,
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function normaliseAllowance(item) {
+  return {
+    key: item.key || slugify(item.label || 'allowance'),
+    label: item.label || prettifyKey(item.key || 'Allowance'),
+    used: toNumber(item.used, 0),
+    total: toNumber(item.total, 0),
+    updatedAt: item.updatedAt || null,
+  };
+}
+
+function allowanceStatus(used, total) {
+  const u = toNumber(used, 0);
+  const t = toNumber(total, 0);
+  if (!t) return 'info';
+  const ratio = t ? u / t : 0;
+  if (ratio >= 1) return 'exhausted';
+  if (ratio >= 0.85) return 'attention';
+  if (ratio >= 0.5) return 'tracking';
+  return 'available';
+}
+
+function prettifyKey(key) {
+  if (!key) return 'Allowance';
+  return String(key)
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
+function slugify(label) {
+  return String(label || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    || 'item';
+}
+
+function buildPayments(meta, allowances) {
+  const payments = Array.isArray(meta.paymentsOnAccount) ? meta.paymentsOnAccount : [];
+  if (payments.length) {
+    return payments.map((item) => ({
+      reference: item.reference || item.period || null,
+      dueDate: normaliseDate(item.dueDate),
+      amount: toNumber(item.amount, item.value),
+      status: item.status || 'due',
+      note: item.note || item.description || null,
+    })).sort(byDueDate);
+  }
+
+  const personal = allowances.find((a) => a.key === 'personalAllowance');
+  const baseline = toNumber(meta?.kpis?.hmrc?.estTaxAnnual, toNumber(meta.estimatedTax, 0));
+  const estimate = baseline > 0 ? baseline / 2 : Math.max(0, toNumber(meta.expectedPaymentOnAccount, 0));
+
+  const jan = upcomingDueDate(0, 31, 1); // 31 January
+  const jul = upcomingDueDate(6, 31, 2); // 31 July (month index 6 => July)
+
+  return [
+    {
+      reference: `${taxYearLabel(jan)} POA 1`,
+      dueDate: jan,
+      amount: Math.round(estimate || Math.max(0, (personal?.used || 0) * 0.4)),
+      status: 'projected',
+      note: 'First payment on account for the current tax year.',
+    },
+    {
+      reference: `${taxYearLabel(jul)} POA 2`,
+      dueDate: jul,
+      amount: Math.round(estimate || Math.max(0, (personal?.used || 0) * 0.4)),
+      status: 'projected',
+      note: 'Second payment on account for the current tax year.',
+    },
+  ];
+}
+
+function buildObligations(meta, payments) {
+  const obligations = Array.isArray(meta.obligations) ? meta.obligations : [];
+  if (obligations.length) {
+    return obligations
+      .map((item) => ({
+        label: item.label || item.title || prettifyKey(item.type || 'obligation'),
+        dueDate: normaliseDate(item.dueDate || item.deadline),
+        status: item.status || 'due',
+        period: item.period || null,
+        type: item.type || 'filing',
+        note: item.note || item.description || null,
+      }))
+      .sort(byDueDate);
+  }
+
+  const filingDate = upcomingDueDate(0, 31, 1); // 31 January filing
+  const paymentsMapped = payments.map((p) => ({
+    label: 'Payment on account',
+    dueDate: p.dueDate,
+    status: p.status,
+    period: p.reference,
+    type: 'payment',
+    note: p.note,
+  }));
+
+  return [
+    {
+      label: 'Submit Self Assessment return',
+      dueDate: filingDate,
+      status: 'due',
+      period: taxYearLabel(filingDate),
+      type: 'filing',
+      note: 'Online filing deadline for the previous tax year.',
+    },
+    ...paymentsMapped,
+  ].sort(byDueDate);
+}
+
+function buildBalances(meta, payments) {
+  const sa = meta.balances?.selfAssessment || {};
+  const net = toNumber(sa.net, meta?.kpis?.hmrc?.netForRange || 0);
+  const debit = Math.max(0, toNumber(sa.debit, net > 0 ? net : 0));
+  const credit = Math.max(0, toNumber(sa.credit, net < 0 ? Math.abs(net) : 0));
+  const label = sa.label || meta?.kpis?.hmrc?.label || (net > 0 ? 'Amount due to HMRC' : net < 0 ? 'HMRC owes you' : 'Settled');
+
+  const breakdown = Array.isArray(sa.breakdown)
+    ? sa.breakdown.map((item) => ({
+        reference: item.reference || item.label || null,
+        amount: toNumber(item.amount, 0),
+        dueDate: normaliseDate(item.dueDate),
+        status: item.status || 'due',
+      }))
+    : payments.map((p) => ({ reference: p.reference, amount: p.amount, dueDate: p.dueDate, status: p.status }));
+
+  return {
+    net,
+    debit,
+    credit,
+    label,
+    updatedAt: sa.updatedAt || meta.updatedAt || null,
+    breakdown,
+  };
+}
+
+async function buildDocuments(userId) {
+  const index = await readJsonSafe(paths.docsIndex, []);
+  const mine = index.filter((row) => String(row.userId) === String(userId));
+  const latestByType = new Map();
+  mine.forEach((row) => {
+    const key = row.type || 'other';
+    const current = latestByType.get(key);
+    if (!current) {
+      latestByType.set(key, row);
+      return;
+    }
+    const currentDate = new Date(current.uploadDate || 0).getTime();
+    const nextDate = new Date(row.uploadDate || 0).getTime();
+    if (Number.isFinite(nextDate) && nextDate > currentDate) {
+      latestByType.set(key, row);
+    }
+  });
+
+  return REQUIRED_DOCUMENTS.map((doc) => {
+    const latest = latestByType.get(doc.key) || null;
+    const uploadedAt = latest?.uploadDate || null;
+    const fresh = isDocumentFresh(doc.cadence, uploadedAt);
+    return {
+      key: doc.key,
+      label: doc.label,
+      required: true,
+      lastUploadedAt: uploadedAt,
+      uploadedCount: mine.filter((row) => (row.type || 'other') === doc.key).length,
+      status: fresh ? 'complete' : latest ? 'stale' : 'missing',
+    };
+  });
+}
+
+function isDocumentFresh(cadence, uploadedAt) {
+  if (!uploadedAt) return false;
+  const uploaded = dayjs(uploadedAt);
+  if (!uploaded.isValid()) return false;
+  const now = dayjs();
+  if (cadence?.adhoc) return true;
+  if (cadence?.months) {
+    return uploaded.add(cadence.months, 'month').isAfter(now);
+  }
+  if (cadence?.yearlyBy) {
+    const [monthStr, dayStr] = String(cadence.yearlyBy).split('-');
+    const month = Number(monthStr) - 1;
+    const day = Number(dayStr);
+    let due = dayjs().month(month >= 0 ? month : 0).date(day || 1);
+    if (due.isBefore(uploaded)) due = uploaded.add(1, 'year');
+    if (now.isAfter(due)) {
+      return uploaded.isAfter(due.subtract(1, 'year'));
+    }
+    return uploaded.add(1, 'year').isAfter(due);
+  }
+  return false;
+}
+
+function buildAiSeed({ hmrc, allowances, paymentsOnAccount, obligations, balances, documents }) {
+  const lines = [];
+  if (hmrc?.status === 'connected') {
+    lines.push('HMRC integration: connected');
+    if (hmrc.lastCheckedAt) lines.push(`Last sync: ${new Date(hmrc.lastCheckedAt).toISOString()}`);
+  } else {
+    lines.push('HMRC integration: not connected (using estimates)');
+  }
+  if (balances) {
+    lines.push(`HMRC net position: £${toNumber(balances.net, 0).toLocaleString('en-GB', { maximumFractionDigits: 0 })}`);
+  }
+  if (allowances?.length) {
+    const top = allowances
+      .slice()
+      .sort((a, b) => b.percentUsed - a.percentUsed)
+      .slice(0, 5)
+      .map((a) => `${a.label}: ${a.percentUsed}% used`);
+    lines.push('Allowances snapshot:');
+    lines.push(...top.map((s) => `- ${s}`));
+  }
+  if (paymentsOnAccount?.length) {
+    lines.push('Payments on account:');
+    paymentsOnAccount.forEach((p) => {
+      lines.push(`- ${p.reference || 'Payment'} £${toNumber(p.amount, 0).toLocaleString('en-GB', { maximumFractionDigits: 0 })} due ${formatDate(p.dueDate)}`);
+    });
+  }
+  if (obligations?.length) {
+    const next = obligations[0];
+    if (next) {
+      lines.push(`Next obligation: ${next.label} due ${formatDate(next.dueDate)}`);
+    }
+  }
+  const outstandingDocs = (documents || []).filter((doc) => doc.status !== 'complete');
+  if (outstandingDocs.length) {
+    lines.push('Evidence gaps: ' + outstandingDocs.map((d) => d.label).join(', '));
+  }
+  return lines.join('\n');
+}
+
+function buildQuickActions({ allowances, paymentsOnAccount, obligations, balances }) {
+  const nextDue = obligations?.[0];
+  const remainingDividend = allowances?.find((a) => a.key === 'dividendAllowance');
+  const pension = allowances?.find((a) => a.key === 'pensionAnnual');
+  const netLabel = balances?.label || 'HMRC position';
+
+  return [
+    {
+      id: 'poa-cover',
+      label: 'Will my payments on account cover the bill?',
+      prompt: `Review my current HMRC position (${netLabel}) and payments on account to confirm whether they are enough to cover the upcoming balancing payment. Highlight any shortfall and actions to close it.`,
+    },
+    {
+      id: 'allowance-plan',
+      label: 'Plan allowance usage before year end',
+      prompt: `Given the allowance usage (${formatAllowancePrompt(allowances)}), outline the most impactful actions I should take before tax year end to stay tax efficient.`,
+    },
+    {
+      id: 'deadline-prep',
+      label: `Prepare for ${nextDue ? formatDate(nextDue.dueDate) : 'my next deadline'}`,
+      prompt: `Create a preparation checklist for the upcoming obligation "${nextDue ? nextDue.label : 'Self Assessment'}" including payments on account (${formatPaymentsPrompt(paymentsOnAccount)}) and any evidence to gather.`,
+    },
+    {
+      id: 'pension-scenario',
+      label: 'Compare extra pension contributions',
+      prompt: `Use the snapshot to assess the impact of contributing an extra £2,000 into my pension${pension ? ` (remaining allowance £${Math.max(0, toNumber(pension.remaining, 0)).toLocaleString('en-GB')})` : ''}. Quantify tax relief and updated take-home.`,
+    },
+  ];
+}
+
+function formatAllowancePrompt(allowances = []) {
+  if (!allowances.length) return 'no allowance data';
+  return allowances
+    .map((a) => `${a.label} ${a.percentUsed}% used`)
+    .join('; ');
+}
+
+function formatPaymentsPrompt(payments = []) {
+  if (!payments.length) return 'no scheduled payments';
+  return payments
+    .map((p) => `${p.reference || 'Payment'} £${toNumber(p.amount, 0).toLocaleString('en-GB')} due ${formatDate(p.dueDate)}`)
+    .join('; ');
+}
+
+function buildBaseline(meta, payments) {
+  const baseline = meta.scenarioBaseline || {};
+  const totalTax = toNumber(baseline.totalTax, meta?.kpis?.hmrc?.estTaxAnnual || meta.estimatedTax || 0);
+  const takeHome = toNumber(baseline.takeHome, meta.takeHome || 0);
+  const description = baseline.description || meta.baselineDescription || 'Current HMRC projection based on synced data.';
+  const due = payments?.[0];
+  return {
+    label: baseline.label || 'Current projection',
+    totalTax,
+    takeHome,
+    description: due ? `${description} Next due: ${formatDate(due.dueDate)}.` : description,
+  };
+}
+
+function buildScenarioDeltas(meta, allowances, payments) {
+  const scenarios = Array.isArray(meta.scenarios) ? meta.scenarios : [];
+  if (scenarios.length) {
+    return scenarios.map((item) => ({
+      id: item.id || slugify(item.label || item.name || 'scenario'),
+      label: item.label || item.name || 'Scenario',
+      summary: item.summary || item.description || null,
+      taxDelta: toNumber(item.taxDelta, item.delta?.tax),
+      takeHomeDelta: toNumber(item.takeHomeDelta, item.delta?.takeHome),
+      allowanceImpact: item.allowanceImpact || item.delta?.allowances || null,
+    }));
+  }
+
+  const dividend = allowances.find((a) => a.key === 'dividendAllowance');
+  const cgt = allowances.find((a) => a.key === 'cgtAllowance');
+  const pension = allowances.find((a) => a.key === 'pensionAnnual');
+  const payment = payments?.[0];
+
+  return [
+    {
+      id: 'dividend-top-up',
+      label: 'Use remaining dividend allowance',
+      summary: dividend
+        ? `Model taking dividends to fill the remaining £${Math.max(0, dividend.remaining).toLocaleString('en-GB')} allowance.`
+        : 'Model topping up dividends within the basic allowance.',
+      taxDelta: dividend ? Math.round(Math.max(0, dividend.remaining) * 0.075) : 0,
+      takeHomeDelta: dividend ? Math.round(Math.max(0, dividend.remaining) * 0.925) : 0,
+      allowanceImpact: { key: dividend?.key || 'dividendAllowance', remainingAfter: Math.max(0, (dividend?.remaining || 0) - (dividend?.remaining || 0)) },
+    },
+    {
+      id: 'bed-and-isa',
+      label: 'Harvest gains and shelter in ISA',
+      summary: cgt
+        ? `Compare realising £${Math.max(0, Math.min(cgt.remaining, 3000)).toLocaleString('en-GB')} in gains and re-buying within the ISA.`
+        : 'Compare crystallising gains and moving into ISA to avoid future CGT.',
+      taxDelta: cgt ? -Math.round(Math.max(0, Math.min(cgt.remaining, 3000)) * 0.1) : -300,
+      takeHomeDelta: cgt ? 0 : 0,
+      allowanceImpact: { key: cgt?.key || 'cgtAllowance', remainingAfter: Math.max(0, (cgt?.remaining || 0) - Math.min(cgt?.remaining || 0, 3000)) },
+    },
+    {
+      id: 'pension-boost',
+      label: 'Add £2k pension contribution',
+      summary: pension
+        ? `Evaluate adding £2,000 gross to pension (${Math.max(0, pension.remaining).toLocaleString('en-GB')} allowance remaining).`
+        : 'Evaluate extra £2,000 pension contribution and relief.',
+      taxDelta: -800,
+      takeHomeDelta: -1200,
+      allowanceImpact: { key: pension?.key || 'pensionAnnual', remainingAfter: Math.max(0, (pension?.remaining || 0) - 2000) },
+    },
+    {
+      id: 'poa-shortfall',
+      label: 'Catch up a payment on account shortfall',
+      summary: payment
+        ? `Quantify topping up the ${payment.reference || 'next payment'} due ${formatDate(payment.dueDate)} if the estimate increases by £1,500.`
+        : 'Quantify the impact of HMRC increasing the payment on account requirement by £1,500.',
+      taxDelta: 1500,
+      takeHomeDelta: -1500,
+      allowanceImpact: null,
+    },
+  ];
+}
+
+function normaliseDate(date) {
+  if (!date) return null;
+  const d = dayjs(date);
+  if (!d.isValid()) return null;
+  return d.toISOString();
+}
+
+function byDueDate(a, b) {
+  const ad = a?.dueDate ? new Date(a.dueDate).getTime() : Infinity;
+  const bd = b?.dueDate ? new Date(b.dueDate).getTime() : Infinity;
+  return ad - bd;
+}
+
+function upcomingDueDate(monthIndex, day, offset) {
+  const now = dayjs();
+  let due = dayjs().month(monthIndex).date(day);
+  if (due.isBefore(now)) due = due.add(offset || 1, 'year');
+  return due.toISOString();
+}
+
+function taxYearLabel(dateIso) {
+  const d = dayjs(dateIso);
+  const year = d.month() >= 3 ? d.year() : d.year() - 1; // tax year starts 6 April
+  return `${year}/${String(year + 1).slice(-2)}`;
+}
+
+function formatDate(dateIso) {
+  if (!dateIso) return '—';
+  const d = dayjs(dateIso);
+  if (!d.isValid()) return '—';
+  return d.format('D MMM YYYY');
+}

--- a/frontend/components/sidebar.html
+++ b/frontend/components/sidebar.html
@@ -51,6 +51,11 @@
       <span class="label">Scenario Lab</span>
     </a>
 
+    <a href="/tax-lab.html" class="app-nav-item" data-route="tax-lab.html" title="Tax Lab">
+      <i class="bi bi-calculator"></i>
+      <span class="label">Tax Lab</span>
+    </a>
+
     <a href="/document-vault.html" class="app-nav-item" data-route="document-vault.html" title="Document Vault">
       <i class="bi bi-safe2"></i>
       <span class="label">Document Vault</span>

--- a/frontend/js/mobile-sidebar.js
+++ b/frontend/js/mobile-sidebar.js
@@ -20,6 +20,7 @@
     'wealth-lab.html': 'Experiment with investments and long-term goals.',
     'billing.html': 'Manage your subscription, invoices, and payments.',
     'scenario-lab.html': 'Test tax and cashflow outcomes before you commit.',
+    'tax-lab.html': 'Summarise HMRC balances, allowances, and filing tasks.',
     'document-vault.html': 'Secure repository for statements and evidence.',
     'gifts.html': 'Track gifting, IHT allowances, and beneficiaries.',
     'profile.html': 'Edit contact details, preferences, and security.'

--- a/frontend/js/tax-lab.js
+++ b/frontend/js/tax-lab.js
@@ -1,0 +1,431 @@
+// frontend/js/tax-lab.js
+(function () {
+  const state = {
+    snapshot: null,
+    scenarios: null,
+    ai: {
+      busy: false,
+      lastPrompt: null,
+    },
+  };
+
+  const byId = (id) => document.getElementById(id);
+
+  init().catch((err) => {
+    console.error('Failed to initialise tax lab', err);
+    showError('Unable to load HMRC snapshot. Please refresh.');
+  });
+
+  async function init() {
+    Auth.setBannerTitle('Tax Lab');
+    await Auth.requireAuth();
+    await loadData();
+    bindEvents();
+    render();
+  }
+
+  async function loadData() {
+    const [snapRes, scenariosRes] = await Promise.all([
+      Auth.fetch('/api/tax/snapshot', { cache: 'no-store' }),
+      Auth.fetch('/api/tax/scenarios', { cache: 'no-store' }).catch(() => null),
+    ]);
+
+    if (!snapRes?.ok) {
+      const detail = await snapRes?.text?.().catch(() => '');
+      throw new Error(detail || 'snapshot failed');
+    }
+
+    state.snapshot = await snapRes.json();
+
+    if (scenariosRes && scenariosRes.ok) {
+      state.scenarios = await scenariosRes.json();
+    } else {
+      state.scenarios = { baseline: null, deltas: [] };
+    }
+  }
+
+  function bindEvents() {
+    const quickRoot = byId('ai-quick-actions');
+    if (quickRoot) {
+      quickRoot.addEventListener('click', (ev) => {
+        const btn = ev.target.closest('[data-prompt]');
+        if (!btn) return;
+        ev.preventDefault();
+        if (state.ai.busy) return;
+        runQuickAction(btn.dataset.prompt, btn);
+      });
+    }
+  }
+
+  function render() {
+    if (!state.snapshot) return;
+    renderHeader();
+    renderSummaryCards();
+    renderAllowances();
+    renderPayments();
+    renderObligations();
+    renderDocuments();
+    renderScenarios();
+    renderQuickActions();
+  }
+
+  function renderHeader() {
+    const label = byId('hmrc-sync-label');
+    const sub = byId('hmrc-sync-sub');
+    const snap = state.snapshot;
+    const connected = snap.integrations?.hmrcConnected;
+    if (label) {
+      label.textContent = connected ? 'HMRC sync active' : 'Using estimates';
+      label.classList.toggle('text-bg-light', !connected);
+      label.classList.toggle('text-bg-warning', !connected);
+      label.classList.toggle('text-bg-success', !!connected);
+      label.classList.toggle('border', !connected);
+    }
+    if (sub) {
+      const ts = snap.integrations?.lastSync || snap.updatedAt;
+      sub.textContent = ts ? `Last updated ${formatDate(ts)}` : 'No sync recorded yet.';
+    }
+  }
+
+  function renderSummaryCards() {
+    const snap = state.snapshot;
+    setText('tax-code-value', snap.personalTaxCode?.code || '—');
+    setText('tax-code-sub', snap.personalTaxCode?.source === 'hmrc' ? 'From HMRC portal' : 'Estimated from records');
+
+    const net = Number(snap.hmrcBalances?.net ?? 0);
+    setText('tax-net-value', formatMoney(net));
+    setText('tax-net-sub', snap.hmrcBalances?.label || '—');
+
+    const next = (snap.obligations || [])[0];
+    setText('tax-next-label', next ? formatDate(next.dueDate) : '—');
+    setText('tax-next-sub', next ? next.label : 'No upcoming obligations');
+
+    const docs = snap.documents || [];
+    const completed = docs.filter((d) => d.status === 'complete').length;
+    const required = docs.length || 0;
+    setText('tax-doc-progress', required ? `${completed}/${required}` : '—');
+    setText('tax-doc-sub', required ? 'Required items uploaded' : 'No required documents listed');
+  }
+
+  function renderAllowances() {
+    const wrap = byId('allowance-list');
+    if (!wrap) return;
+    const allowances = state.snapshot.allowances || [];
+    const updated = state.snapshot.allowances?.[0]?.updatedAt || state.snapshot.updatedAt;
+    setText('allowance-updated', updated ? `Updated ${formatDate(updated)}` : 'No update timestamp');
+
+    if (!allowances.length) {
+      wrap.innerHTML = '<div class="text-muted small">No allowance data available. Connect HMRC to populate this view.</div>';
+      return;
+    }
+
+    wrap.innerHTML = '';
+    allowances.forEach((a) => {
+      const row = document.createElement('div');
+      row.className = 'allowance-row';
+      row.innerHTML = `
+        <div class="d-flex justify-content-between align-items-start">
+          <div>
+            <div class="label">${escapeHtml(a.label)}</div>
+            <div class="meta">${formatMoney(a.used)} used of ${formatMoney(a.total)} (${a.percentUsed}% used)</div>
+          </div>
+          <span class="badge bg-${badgeFromStatus(a.status)}">${statusLabel(a.status)}</span>
+        </div>
+        <div class="progress mt-2" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${a.percentUsed}">
+          <div class="progress-bar bg-${barFromStatus(a.status)}" style="width:${a.percentUsed}%"></div>
+        </div>
+      `;
+      wrap.appendChild(row);
+    });
+  }
+
+  function renderPayments() {
+    const tbody = byId('payments-body');
+    if (!tbody) return;
+    const list = state.snapshot.paymentsOnAccount || [];
+    if (!list.length) {
+      tbody.innerHTML = '<tr><td colspan="4" class="text-muted small">No payments scheduled.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = '';
+    list.forEach((item) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${escapeHtml(item.reference || '—')}</td>
+        <td class="text-end">${formatMoney(item.amount)}</td>
+        <td>${formatDate(item.dueDate)}</td>
+        <td><span class="badge bg-${badgeFromStatus(item.status)}">${statusLabel(item.status)}</span></td>
+      `;
+      tbody.appendChild(tr);
+    });
+  }
+
+  function renderObligations() {
+    const list = byId('obligation-list');
+    if (!list) return;
+    const data = state.snapshot.obligations || [];
+    if (!data.length) {
+      list.innerHTML = '<li><span class="text-muted small">No obligations on file.</span></li>';
+      return;
+    }
+    list.innerHTML = '';
+    data.forEach((item) => {
+      const li = document.createElement('li');
+      li.innerHTML = `
+        <div class="fw-semibold">${escapeHtml(item.label)}</div>
+        <div class="text-muted small">${formatDate(item.dueDate)} · ${escapeHtml(item.period || item.type || '')}</div>
+        ${item.note ? `<div class="small">${escapeHtml(item.note)}</div>` : ''}
+      `;
+      list.appendChild(li);
+    });
+  }
+
+  function renderDocuments() {
+    const wrap = byId('documents-list');
+    if (!wrap) return;
+    const docs = state.snapshot.documents || [];
+    if (!docs.length) {
+      wrap.innerHTML = '<div class="text-muted small">No required documents defined.</div>';
+      return;
+    }
+    wrap.innerHTML = '';
+    docs.forEach((doc) => {
+      const div = document.createElement('div');
+      div.className = `doc-status ${doc.status}`;
+      div.innerHTML = `
+        <div>
+          <div class="label">${escapeHtml(doc.label)}</div>
+          <div class="small text-muted">${doc.lastUploadedAt ? `Last uploaded ${formatDate(doc.lastUploadedAt)}` : 'No upload yet'}</div>
+        </div>
+        <span class="badge bg-${badgeFromStatus(doc.status)}">${statusLabel(doc.status)}</span>
+      `;
+      wrap.appendChild(div);
+    });
+  }
+
+  function renderScenarios() {
+    const label = byId('scenario-baseline-label');
+    const desc = byId('scenario-baseline-desc');
+    const grid = byId('scenario-grid');
+    if (!grid) return;
+
+    const baseline = state.scenarios?.baseline;
+    if (label) label.textContent = baseline ? `${baseline.label}: tax £${formatNumber(baseline.totalTax)}` : 'Baseline unavailable';
+    if (desc) desc.textContent = baseline?.description || 'Connect HMRC to populate projections.';
+
+    const deltas = state.scenarios?.deltas || [];
+    if (!deltas.length) {
+      grid.innerHTML = '<div class="text-muted small">No scenarios computed yet.</div>';
+      return;
+    }
+
+    grid.innerHTML = '';
+    deltas.forEach((item) => {
+      const card = document.createElement('div');
+      card.className = 'scenario-card';
+      card.innerHTML = `
+        <h3 class="h6">${escapeHtml(item.label)}</h3>
+        <div class="small text-muted mb-2">${item.summary ? escapeHtml(item.summary) : 'Scenario impact overview.'}</div>
+        <div class="d-flex flex-column gap-1">
+          <div><span class="fw-semibold">Tax delta:</span> ${formatMoney(item.taxDelta)}</div>
+          <div><span class="fw-semibold">Take-home delta:</span> ${formatMoney(item.takeHomeDelta)}</div>
+        </div>
+      `;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderQuickActions() {
+    const wrap = byId('ai-quick-actions');
+    if (!wrap) return;
+    const actions = state.snapshot.quickActions || [];
+    if (!actions.length) {
+      wrap.innerHTML = '<div class="text-muted small">No quick actions available.</div>';
+      return;
+    }
+    wrap.innerHTML = '';
+    actions.forEach((action) => {
+      const tile = document.createElement('div');
+      tile.className = 'quick-btn';
+      tile.innerHTML = `
+        <div class="fw-semibold">${escapeHtml(action.label)}</div>
+        <button class="btn btn-sm btn-primary" data-prompt="${escapeAttribute(action.prompt)}">Ask now</button>
+      `;
+      wrap.appendChild(tile);
+    });
+  }
+
+  async function runQuickAction(prompt, button) {
+    const output = byId('ai-quick-output');
+    if (!prompt || !output) return;
+    state.ai.busy = true;
+    state.ai.lastPrompt = prompt;
+    output.textContent = 'Thinking…';
+    const original = button?.innerHTML;
+    if (button) {
+      button.disabled = true;
+      button.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Running';
+    }
+
+    const messages = [
+      {
+        role: 'system',
+        content: `You are the AI Accountant tax assistant. Stay concise, actionable, and cite HMRC processes when relevant. Here is the latest snapshot to ground your answer:\n\n${state.snapshot.aiPromptSeed || ''}`,
+      },
+      { role: 'user', content: prompt },
+    ];
+
+    try {
+      const resp = await Auth.fetch('/api/ai/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages }),
+      });
+      if (!resp.ok || !resp.body) {
+        output.textContent = 'Unable to contact AI service right now.';
+        return;
+      }
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder('utf-8');
+      let buffer = '';
+      let text = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop();
+        for (const chunk of parts) {
+          if (!chunk.startsWith('data:')) continue;
+          const payload = chunk.slice(5).trim();
+          if (!payload || payload === '[DONE]') continue;
+          try {
+            const json = JSON.parse(payload);
+            if (json.error) {
+              output.textContent = json.error;
+              continue;
+            }
+            if (json.delta) {
+              text += json.delta;
+              output.textContent = text.trim();
+            }
+          } catch (err) {
+            console.warn('Failed to parse AI chunk', err, payload);
+          }
+        }
+      }
+      if (!text) output.textContent = 'No response received.';
+    } catch (err) {
+      console.error('AI quick action failed', err);
+      output.textContent = 'Quick action failed. Please try again later.';
+    } finally {
+      state.ai.busy = false;
+      if (button) {
+        button.disabled = false;
+        button.innerHTML = original;
+      }
+    }
+  }
+
+  function showError(msg) {
+    const box = byId('tax-error');
+    if (!box) return;
+    box.textContent = msg;
+    box.classList.remove('d-none');
+  }
+
+  function setText(id, value) {
+    const el = byId(id);
+    if (!el) return;
+    el.textContent = value == null ? '—' : value;
+  }
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeAttribute(value) {
+    return escapeHtml(value).replace(/`/g, '&#96;');
+  }
+
+  function formatMoney(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '£—';
+    return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 0 }).format(n);
+  }
+
+  function formatNumber(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '—';
+    return n.toLocaleString('en-GB', { maximumFractionDigits: 0 });
+  }
+
+  function formatDate(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '—';
+    return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case 'complete':
+        return 'Complete';
+      case 'stale':
+        return 'Refresh soon';
+      case 'missing':
+        return 'Missing';
+      case 'projected':
+        return 'Projected';
+      case 'due':
+        return 'Due';
+      case 'attention':
+        return 'Attention';
+      case 'exhausted':
+        return 'Exhausted';
+      case 'tracking':
+        return 'On track';
+      case 'available':
+        return 'Available';
+      default:
+        return (status || 'Unknown').replace(/\b\w/g, (c) => c.toUpperCase());
+    }
+  }
+
+  function badgeFromStatus(status) {
+    switch (status) {
+      case 'complete':
+      case 'available':
+        return 'success';
+      case 'stale':
+      case 'attention':
+      case 'projected':
+        return 'warning text-dark';
+      case 'exhausted':
+      case 'missing':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+
+  function barFromStatus(status) {
+    switch (status) {
+      case 'complete':
+      case 'available':
+        return 'success';
+      case 'stale':
+      case 'attention':
+        return 'warning';
+      case 'exhausted':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+})();

--- a/frontend/tax-lab.html
+++ b/frontend/tax-lab.html
@@ -1,0 +1,367 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tax Lab — AI Accountant</title>
+  <script src="/js/head-include.js"></script>
+  <style>
+    :root {
+      --lab-muted: #6b7280;
+      --lab-bg: #f8fafc;
+      --card-radius: 18px;
+      --tile-shadow: 0 10px 30px rgba(0,0,0,.06), 0 2px 8px rgba(0,0,0,.05);
+    }
+
+    body {
+      background-color: var(--lab-bg);
+    }
+
+    .lab-hero {
+      padding: 18px 0 8px;
+    }
+
+    .lab-hero .eyebrow {
+      font-size: .78rem;
+      color: var(--lab-muted);
+      text-transform: uppercase;
+      letter-spacing: .08em;
+    }
+
+    .lab-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .5rem 1rem;
+      align-items: center;
+      margin-top: .5rem;
+    }
+
+    .tax-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+    }
+
+    .tax-card {
+      background: #fff;
+      border-radius: var(--card-radius);
+      box-shadow: var(--tile-shadow);
+      border: 1px solid rgba(0,0,0,.05);
+      padding: 16px;
+      min-height: 120px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+
+    .tax-card h3 {
+      font-size: 1.05rem;
+      margin: 0 0 .25rem;
+    }
+
+    .tax-card .value {
+      font-size: 1.8rem;
+      font-weight: 600;
+      line-height: 1.2;
+    }
+
+    .tax-card .sub {
+      color: var(--lab-muted);
+      font-size: .9rem;
+    }
+
+    .section-card {
+      background: #fff;
+      border-radius: var(--card-radius);
+      box-shadow: var(--tile-shadow);
+      border: 1px solid rgba(0,0,0,.05);
+      margin-bottom: 20px;
+    }
+
+    .section-card .card-header {
+      padding: 18px 18px 12px;
+      border-bottom: 1px solid rgba(0,0,0,.05);
+    }
+
+    .section-card .card-body {
+      padding: 18px;
+    }
+
+    .allowance-row + .allowance-row {
+      margin-top: 14px;
+    }
+
+    .allowance-row .label {
+      font-weight: 500;
+    }
+
+    .allowance-row .meta {
+      font-size: .85rem;
+      color: var(--lab-muted);
+    }
+
+    .progress {
+      height: 8px;
+      border-radius: 999px;
+    }
+
+    .progress-bar {
+      border-radius: 999px;
+    }
+
+    .doc-status {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: .5rem;
+      padding: 10px 12px;
+      border: 1px dashed rgba(0,0,0,.08);
+      border-radius: 12px;
+      background: rgba(148, 163, 184, .08);
+    }
+
+    .doc-status.missing {
+      border-style: solid;
+      border-color: rgba(220, 38, 38, .3);
+      background: rgba(248, 113, 113, .08);
+    }
+
+    .doc-status.stale {
+      border-color: rgba(234, 179, 8, .4);
+      background: rgba(254, 240, 138, .2);
+    }
+
+    .doc-status.complete {
+      border-color: rgba(16, 163, 127, .35);
+      background: rgba(16, 163, 127, .12);
+    }
+
+    .doc-status .label {
+      font-weight: 500;
+    }
+
+    .timeline {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .timeline li {
+      position: relative;
+      padding-left: 28px;
+      margin-bottom: 16px;
+    }
+
+    .timeline li::before {
+      content: '';
+      position: absolute;
+      left: 10px;
+      top: 6px;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: #0d6efd;
+      box-shadow: 0 0 0 4px rgba(13,110,253,.2);
+    }
+
+    .timeline li:last-child {
+      margin-bottom: 0;
+    }
+
+    .quick-actions {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 12px;
+    }
+
+    .quick-btn {
+      background: #fff;
+      border: 1px solid rgba(0,0,0,.08);
+      border-radius: 14px;
+      padding: 14px;
+      text-align: left;
+      box-shadow: var(--tile-shadow);
+      display: flex;
+      flex-direction: column;
+      gap: .5rem;
+      transition: transform .15s ease, box-shadow .15s ease;
+    }
+
+    .quick-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 14px 30px rgba(15,23,42,.15);
+    }
+
+    .quick-btn button {
+      align-self: flex-start;
+    }
+
+    #ai-quick-output {
+      min-height: 120px;
+      white-space: pre-wrap;
+      font-size: .95rem;
+    }
+
+    .scenario-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 16px;
+    }
+
+    .scenario-card {
+      border: 1px solid rgba(0,0,0,.08);
+      border-radius: 14px;
+      padding: 14px;
+      background: #fff;
+      box-shadow: var(--tile-shadow);
+    }
+
+    @media (max-width: 992px) {
+      body { background: #fff; }
+      .section-card { box-shadow: none; border-radius: 12px; }
+      .tax-card { border-radius: 14px; }
+    }
+  </style>
+</head>
+<body>
+  <div id="topbar-container"></div>
+  <div id="sidebar-container"></div>
+
+  <main class="container py-4">
+    <section class="lab-hero">
+      <div class="eyebrow">Labs</div>
+      <h1 class="page-title" data-page-title data-lock-title>Tax Lab</h1>
+      <p class="text-muted small mb-0">Summaries for Self Assessment, HMRC balances, and evidence readiness.</p>
+      <div class="lab-meta">
+        <span class="badge text-bg-light border" id="hmrc-sync-label">Checking HMRC sync…</span>
+        <span class="text-muted small" id="hmrc-sync-sub"></span>
+      </div>
+    </section>
+
+    <div id="tax-error" class="alert alert-danger d-none" role="alert"></div>
+
+    <section class="tax-cards" id="tax-summary-cards">
+      <article class="tax-card">
+        <div>
+          <h3>Personal tax code</h3>
+          <div class="value" id="tax-code-value">—</div>
+        </div>
+        <div class="sub" id="tax-code-sub">Awaiting data…</div>
+      </article>
+      <article class="tax-card">
+        <div>
+          <h3>HMRC net position</h3>
+          <div class="value" id="tax-net-value">£—</div>
+        </div>
+        <div class="sub" id="tax-net-sub">—</div>
+      </article>
+      <article class="tax-card">
+        <div>
+          <h3>Next obligation</h3>
+          <div class="value" id="tax-next-label">—</div>
+        </div>
+        <div class="sub" id="tax-next-sub">—</div>
+      </article>
+      <article class="tax-card">
+        <div>
+          <h3>Evidence completeness</h3>
+          <div class="value" id="tax-doc-progress">—</div>
+        </div>
+        <div class="sub" id="tax-doc-sub">Required items uploaded</div>
+      </article>
+    </section>
+
+    <section class="section-card mt-4">
+      <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+        <div>
+          <h2 class="h5 mb-0">Allowance utilisation</h2>
+          <p class="text-muted small mb-0">Track remaining tax-efficient headroom across key allowances.</p>
+        </div>
+        <span class="badge text-bg-light" id="allowance-updated">—</span>
+      </div>
+      <div class="card-body" id="allowance-list"></div>
+    </section>
+
+    <div class="row g-3">
+      <div class="col-12 col-xl-6">
+        <section class="section-card">
+          <div class="card-header">
+            <h2 class="h5 mb-0">Payments on account</h2>
+            <p class="text-muted small mb-0">Monitor instalments and project upcoming cash requirements.</p>
+          </div>
+          <div class="card-body">
+            <div class="table-responsive">
+              <table class="table align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th scope="col">Reference</th>
+                    <th scope="col" class="text-end">Amount</th>
+                    <th scope="col">Due</th>
+                    <th scope="col">Status</th>
+                  </tr>
+                </thead>
+                <tbody id="payments-body">
+                  <tr><td colspan="4" class="text-muted small">No payments scheduled.</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div class="col-12 col-xl-6">
+        <section class="section-card">
+          <div class="card-header">
+            <h2 class="h5 mb-0">Upcoming obligations</h2>
+            <p class="text-muted small mb-0">Stay ahead of filing deadlines and HMRC milestones.</p>
+          </div>
+          <div class="card-body">
+            <ul class="timeline" id="obligation-list"></ul>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <section class="section-card">
+      <div class="card-header">
+        <h2 class="h5 mb-0">Required evidence coverage</h2>
+        <p class="text-muted small mb-0">Documents HMRC commonly expects for Self Assessment and related workflows.</p>
+      </div>
+      <div class="card-body" id="documents-list"></div>
+    </section>
+
+    <section class="section-card">
+      <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+        <div>
+          <h2 class="h5 mb-0">Scenario deltas</h2>
+          <p class="text-muted small mb-0">Compare hypothetical moves against the current HMRC projection.</p>
+        </div>
+        <span class="badge text-bg-light" id="scenario-baseline-label">—</span>
+      </div>
+      <div class="card-body">
+        <p class="text-muted small" id="scenario-baseline-desc">—</p>
+        <div class="scenario-grid" id="scenario-grid"></div>
+      </div>
+    </section>
+
+    <section class="section-card mb-5">
+      <div class="card-header">
+        <h2 class="h5 mb-0">Quick AI actions</h2>
+        <p class="text-muted small mb-0">Launch seeded prompts with the latest tax snapshot context.</p>
+      </div>
+      <div class="card-body">
+        <div class="quick-actions" id="ai-quick-actions"></div>
+        <hr class="my-4" />
+        <h3 class="h6">AI response</h3>
+        <div id="ai-quick-output" class="p-3 border rounded bg-light text-muted">Select an action to generate guidance.</div>
+      </div>
+    </section>
+  </main>
+
+  <script src="/js/nav.js"></script>
+  <script src="/js/mobile-sidebar.js"></script>
+  <script src="/js/config.js"></script>
+  <script src="/js/auth.js"></script>
+  <script>Auth.enforce();</script>
+  <script src="/js/tax-lab.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add backend tax snapshot and scenario endpoints that aggregate HMRC balances, allowances, obligations, and evidence coverage
- introduce a shared required-document catalogue for reuse by new services
- build a Tax Lab frontend with AI quick actions and wire it into the sidebar and mobile bento navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e32a45f9208321b89fcced248ea0c3