### PR TITLE
feat(worker): initial background worker service with health endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ frontend/.env
 # Uploads / generated
 uploads/
 backend/uploads/
+services/worker/dist/
 *.DS_Store

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -7,6 +7,9 @@ const { paths, readJsonSafe } = require('../src/store/jsondb');
 
 const router = express.Router();
 
+// TODO(analytics-cache): Swap range parsing + payload assembly to read from AnalyticsCache
+// and trigger background recompute via /_internal/analytics/recompute (see docs/compatibility-map.md).
+
 const REQUIRED_DOC_TYPES = [
   { type: 'p60', label: 'P60' },
   { type: 'p45', label: 'P45 / starter checklist' },
@@ -79,6 +82,7 @@ function prevComparableRange(range) {
   return { start: prevStart, end: prevEnd };
 }
 
+// TODO(analytics-cache): Retire ad-hoc usage stats once DocChecklist + AnalyticsCache models land.
 async function computeUsageStats(userId, range) {
   try {
     const [txAll, docsIndex, accounts] = await Promise.all([

--- a/backend/services/analytics/personalFinance.js
+++ b/backend/services/analytics/personalFinance.js
@@ -14,6 +14,9 @@ dayjs.extend(isSameOrBefore);
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const cache = new Map();
 
+// TODO(worker-refactor): Extract pure analytics modules (ranges, cashflow, hmrc, etc.)
+// so BullMQ workers can compute and persist AnalyticsCache payloads independent of Express.
+
 const CPI_INDEX = new Map([
   ['2023-10', 127.4],
   ['2023-11', 127.7],

--- a/docs/compatibility-map.md
+++ b/docs/compatibility-map.md
@@ -1,0 +1,51 @@
+# Compatibility Map: Analytics & Document Pipeline Overhaul
+
+## Current Endpoint Surface vs Target Changes
+| Current route | Responsibility today | Planned endpoint/state | Notes |
+| --- | --- | --- | --- |
+| `GET /api/analytics/dashboard`【F:backend/routes/analytics.js†L9-L123】【F:backend/routes/analytics.js†L200-L234】 | Builds dashboard payload directly from `User` document plus filesystem JSON helpers (transactions, docs index) and returns empty stubs for most analytics arrays. | Same route, but should become a thin controller that validates range params, reads cached analytics from `AnalyticsCache`, and triggers background recompute when stale via `/\_internal/analytics/recompute`. | Needs schema-hash validation, provenance metadata, and cache freshness enforcement per the plan.【F:docs/analytics-calculation-plan.md†L61-L86】【F:docs/analytics-calculation-plan.md†L169-L201】 |
+| `GET /api/vault/...` & `POST /api/vault/upload` (R2-backed)【F:backend/src/routes/vault.routes.js†L13-L231】 | Handles document upload, collection management, and cataloguing with direct `User.usageStats` updates. | Continue to serve upload UX but, after successful R2 write, call `POST /\_internal/docs/ingest` to enqueue ingest/validation and let workers update `VaultFile` + `DocChecklist`. | Requires passing user + object key to worker, plus antivirus scan + validation hooks before analytics recompute. |
+| `POST /api/plaid/sync` (if exposed) & background `plaidSyncWorker.startPlaidSyncWorker`【F:backend/index.js†L118-L137】【F:backend/services/plaidSyncWorker.js†L1-L209】 | Performs in-process Plaid syncs on an interval. | Replace manual interval with internal task API `POST /\_internal/plaid/sync` called by Render cron/worker. Keep existing Plaid routes for setup. | Stub job should no-op without Plaid keys but keep audit logging.【F:docs/analytics-calculation-plan.md†L117-L153】 |
+| `GET /api/user/preferences` & `PATCH /api/user/preferences` (via dashboard)【F:frontend/js/dashboard.js†L33-L78】 | Stores preferred delta mode/range in Mongo `User.preferences`. | Keep endpoints unchanged but ensure workers respect stored range/delta defaults when computing caches. | Cache key should include `(userId, rangeKey, deltaMode)` to match plan.【F:docs/analytics-calculation-plan.md†L61-L86】 |
+| `GET /api/summary` & `GET /api/ai` (dashboard adjuncts) | Provide supplementary insights/AI messaging today. | Remain read-only; new analytics alerts feed should populate `aiInsights` array so `/api/ai` keeps working without duplication. | Need to deduplicate AI suggestions vs analytics alerts to avoid double messaging. |
+
+### New Internal Endpoints to add (token-gated)
+- `POST /_internal/docs/ingest` → enqueue `doc:ingest` job for `{ userId, key }`.
+- `POST /_internal/analytics/recompute` → enqueue analytics recompute for `{ userId, rangeKey?, deltaMode? }` with idempotency token.
+- `POST /_internal/plaid/sync` → stub job for future Plaid polling.
+
+## Front-end Data Expectations vs Target Payloads
+| UI consumer | Current expectation (shape) | Worker-derived payload requirement |
+| --- | --- | --- |
+| KPI cards (`#kpi-income`, `#kpi-spend`, `#kpi-savings`, `#kpi-hmrc`)【F:frontend/js/dashboard.js†L205-L222】 | Array `accounting.metrics` with entries keyed `income`, `spend`, `savingsCapacity`, `hmrcBalance`, each providing `value`, `format`, optional `delta`, `deltaMode`, `subLabel`. Currently mostly empty. | Populate from worker `cashflow` + `savingsCapacity` modules with deltas computed vs comparable range. HMRC card pulls from `hmrc.balance` payload including outstanding tax. |
+| Comparatives ribbon (`comparison-label`, `delta buttons`)【F:frontend/js/dashboard.js†L198-L215】 | `accounting.comparatives` with `label`, `mode`, `values` (per-metric deltas). | Worker should pre-compute friendly labels (`vs previous period`, `vs prior year`) and supply both absolute & percent deltas based on user preference. |
+| Spend donut + table (`spendByCategory`)【F:frontend/js/dashboard.js†L223-L249】 | Array of `{ category, label, amount, share }`. | Derived from transactions classification (categories & merchants), ensuring share sums to 1 and filtered by date range with delta context for cost movers. |
+| Inflation trend chart (`inflationTrend`)【F:frontend/js/dashboard.js†L250-L280】 | Array of `{ label, nominal, real }`. | Worker must compute CPI-adjusted series using stored CPI data and surface `range` metadata for time axis. |
+| Merchants list (`accounting.merchants`) & duplicates table (`accounting.duplicates`)【F:frontend/js/dashboard.js†L281-L332】 | Arrays of top spend merchants and duplicate groups with amounts/counts. | Produced by `merchants/duplicates` analytics module with deterministic ordering and tie-breaking. |
+| HMRC obligations table (`accounting.obligations`) + gauge tiles (`accounting.allowances`)【F:frontend/js/dashboard.js†L333-L369】 | Obligations array with `dueDate`, `title`, `amountDue`; allowances array with `{ label, used, total }`. | Worker `hmrc` module should aggregate payments vs allowances, compute liability balance, and populate gauge usage percentages. |
+| Alert queue & AI suggestions (`accounting.alerts`, `aiInsights`)【F:frontend/js/dashboard.js†L370-L404】【F:frontend/js/dashboard.js†L120-L174】 | Alert cards with `severity`, `title`, `body`; AI suggestions optionally duplicate alerts. | `dqAlerts` module should emit structured alerts (duplicates, savings shortfall, allowance nearing limit, etc.) along with provenance metadata for AI re-use. |
+| Financial posture widgets (`financialPosture`)【F:frontend/js/dashboard.js†L405-L482】 | Object containing `netWorth`, `breakdown` (assets/liabilities), `liquidity`, `savings`, `assetMix`, `topCosts`, etc., today sourced from `User.wealthPlan.summary`. | Worker `wealth` module must merge wealth plan snapshot with transaction-derived savings capacity, doc progress, and highlight cost movers relative to previous range. |
+| Document checklist progress (`accounting.documents`)【F:backend/routes/analytics.js†L210-L220】 | Simple counts for required/helpful docs based on static list. | Backed by `DocChecklist` & `VaultFile.validation` progress with quality flags, percent complete, and outstanding doc descriptions. |
+
+## Environment Variables to Introduce
+| Variable | Purpose | Notes |
+| --- | --- | --- |
+| `INTERNAL_TASK_SECRET` | Shared secret for header auth on `/_internal` routes. | Use `Authorization: Bearer <token>` check server-side. |
+| `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_PUBLIC_BASE` | Configure Cloudflare R2 client + signed URL host. | Supersede `R2_S3_ENDPOINT`; keep backward-compatible fallback during migration.【F:docs/analytics-calculation-plan.md†L21-L41】 |
+| `REDIS_URL` (or `BULLMQ_REDIS_URL`) | Backing store for BullMQ queues used by worker service. | Ensure least-privilege credentials. |
+| `WORKER_METRICS_API_KEY` | Optional metrics push gateway token for job telemetry. | Enables observability per plan requirements. |
+| `CLAMAV_HOST` / `CLAMAV_PORT` (or provider equivalent) | Antivirus scan endpoint for ingest pipeline before parsing. | Worker should short-circuit if not configured but log requirement. |
+| `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV` (existing) | Keep for Plaid readiness; feature-flag job should detect absence and no-op. | Already referenced today; document for completeness.【F:backend/utils/plaidConfig.js†L16-L53】 |
+
+## Minimal Migration Steps
+1. **Model rollout**: Introduce `VaultFile`, `DocChecklist`, and `AnalyticsCache` Mongo schemas with required indices before enabling worker writes. Backfill from existing `User.usageStats` + JSON docs.
+2. **R2 client upgrade**: Deploy `lib/r2.ts` with new env vars, update backend upload path to record object keys + SHA-256, and ensure Cloudflare Worker can presign downloads.
+3. **Queue infrastructure**: Provision Redis (or alternative) for BullMQ, deploy new `services/worker` container, and configure `/\_internal` secrets.
+4. **Analytics cache cut-over**: Modify `/api/analytics/dashboard` to read from `AnalyticsCache`, trigger recompute on cache miss, and keep serving last-known-good payload to UI.
+5. **Front-end adjustments**: Keep existing components but wire UI to show background refresh indicators and validation badges sourced from new payload fields.
+6. **Operational setup**: Configure Render cron schedules (15m incremental, daily full recompute), Cloudflare Worker for signed R2 access, and run updated CI/CD (lint/typecheck/tests) before release.
+
+## Identified Gaps / TODO Targets
+- Need schema hashing + provenance stamps on cached analytics payloads (commit hash, module versions) to detect drift.【F:docs/analytics-calculation-plan.md†L86-L111】
+- Document validation currently only tallies by filename; ingest pipeline must enrich with detected doc types, page counts, and matching against checklist rules.【F:backend/src/routes/vault.routes.js†L132-L215】
+- Range handling & delta computation live in multiple places (frontend local state vs backend). Extract reusable module to keep worker/controller parity.【F:frontend/js/dashboard.js†L24-L110】【F:backend/routes/analytics.js†L17-L79】

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -134,6 +134,8 @@
   }
 
   async function reloadDashboard() {
+    // TODO(analytics-cache): Once worker-backed cache is live, detect stale payloads and
+    // surface a "refreshing" indicator while background recompute runs.
     setText('dash-year', `Tax year ${safeTaxYearLabel(new Date())}`);
     const st = loadRange();
     const params = new URLSearchParams();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ai-accountant-monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "worker:build": "npm --prefix services/worker run build",
+    "worker:start": "npm --prefix services/worker run start",
+    "worker:start:dev": "npm --prefix services/worker run start:dev",
+    "worker:test": "npm --prefix services/worker run test"
+  }
+}

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-bullseye AS base
+
+WORKDIR /app
+
+# Install system dependencies for PDF parsing and OCR ahead of later steps
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    poppler-utils \
+    libglib2.0-0 \
+    libsm6 \
+    libxrender1 \
+    libxext6 \
+  && rm -rf /var/lib/apt/lists/*
+
+FROM base AS deps
+ENV NODE_ENV=development
+COPY services/worker/package.json services/worker/tsconfig.json ./services/worker/
+RUN npm install --prefix services/worker
+
+FROM deps AS build
+COPY services/worker/src ./services/worker/src
+RUN npm run --prefix services/worker build
+
+FROM base AS runner
+ENV NODE_ENV=production
+COPY services/worker/package.json ./services/worker/package.json
+COPY --from=build /app/services/worker/dist ./services/worker/dist
+RUN npm install --prefix services/worker --omit=dev
+
+CMD ["node", "services/worker/dist/index.js"]

--- a/services/worker/package.json
+++ b/services/worker/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ai-accountant-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "start:dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "test": "echo \"No worker-specific tests yet\""
+  },
+  "dependencies": {
+    "bullmq": "^4.17.0",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "ioredis": "^5.4.1",
+    "mongoose": "^8.5.1",
+    "pino": "^9.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.9",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/services/worker/src/http/health.ts
+++ b/services/worker/src/http/health.ts
@@ -1,0 +1,30 @@
+import express, { Request, Response } from 'express';
+
+export interface HealthRouterOptions {
+  readinessCheck?: () => Promise<boolean> | boolean;
+}
+
+export function createHealthRouter(options: HealthRouterOptions = {}) {
+  const { readinessCheck } = options;
+  const router = express.Router();
+
+  router.get('/healthz', (_req: Request, res: Response) => {
+    res.status(200).json({ status: 'ok' });
+  });
+
+  router.get('/readyz', async (_req: Request, res: Response) => {
+    try {
+      if (readinessCheck) {
+        const ready = await readinessCheck();
+        if (!ready) {
+          return res.status(503).json({ status: 'not_ready' });
+        }
+      }
+      return res.status(200).json({ status: 'ok' });
+    } catch (error) {
+      return res.status(503).json({ status: 'error', message: (error as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import dotenv from 'dotenv';
+import pino from 'pino';
+import { createServer } from 'node:http';
+import { queueManager } from './queues/index.js';
+import { createHealthRouter } from './http/health.js';
+
+dotenv.config();
+
+const logger = pino({ name: 'worker', level: process.env.LOG_LEVEL ?? 'info' });
+
+async function bootstrap() {
+  const port = Number(process.env.WORKER_PORT ?? 8081);
+  const app = express();
+
+  app.use(express.json());
+  app.use(
+    createHealthRouter({
+      readinessCheck: async () => queueManager.isReady(),
+    })
+  );
+
+  const server = createServer(app);
+
+  server.listen(port, async () => {
+    logger.info({ port }, 'Worker HTTP server listening');
+  });
+
+  try {
+    await queueManager.start();
+    logger.info('Worker online');
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to start queues');
+    process.exit(1);
+  }
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    logger.info({ signal }, 'Shutting down worker');
+    server.close();
+    await queueManager.shutdown();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+void bootstrap();

--- a/services/worker/src/queues/bull.ts
+++ b/services/worker/src/queues/bull.ts
@@ -1,0 +1,101 @@
+import { Queue, Worker, QueueScheduler, JobsOptions, Job } from 'bullmq';
+import IORedis, { RedisOptions } from 'ioredis';
+
+export type ProcessorFn<T = unknown> = (data: T) => Promise<void> | void;
+
+export interface BullQueueDriverOptions {
+  connection?: RedisOptions;
+  defaultJobOptions?: JobsOptions;
+}
+
+interface RegisteredWorker<T = unknown> {
+  worker: Worker<T, void, string>;
+  scheduler: QueueScheduler;
+}
+
+export class BullQueueDriver {
+  private queues = new Map<string, Queue>();
+  private workers = new Map<string, RegisteredWorker>();
+  private readonly options: BullQueueDriverOptions;
+  private connection?: IORedis;
+
+  constructor(options: BullQueueDriverOptions = {}) {
+    this.options = options;
+  }
+
+  async ping(): Promise<void> {
+    const connection = this.getConnection();
+    await connection.ping();
+  }
+
+  private getConnection(): IORedis {
+    if (!this.connection) {
+      const redisUrl = process.env.REDIS_URL;
+      if (!redisUrl) {
+        throw new Error('REDIS_URL must be defined to use BullMQ driver');
+      }
+      this.connection = new IORedis(redisUrl, {
+        maxRetriesPerRequest: null,
+        enableReadyCheck: false,
+        ...this.options.connection,
+      });
+    }
+
+    return this.connection;
+  }
+
+  private getQueue(name: string): Queue {
+    if (!this.queues.has(name)) {
+      const queue = new Queue(name, {
+        connection: this.getConnection(),
+        defaultJobOptions: this.options.defaultJobOptions,
+      });
+      this.queues.set(name, queue);
+    }
+
+    return this.queues.get(name)!;
+  }
+
+  registerProcessor<T>(name: string, processor: ProcessorFn<T>) {
+    if (this.workers.has(name)) {
+      return;
+    }
+
+    const connection = this.getConnection();
+    const worker = new Worker<T>(
+      name,
+      async (job: Job<T, void, string>) => {
+        await processor(job.data);
+      },
+      { connection }
+    );
+
+    const scheduler = new QueueScheduler(name, { connection });
+    void scheduler.waitUntilReady();
+
+    this.workers.set(name, { worker, scheduler });
+  }
+
+  async enqueue<T>(name: string, data: T, options?: JobsOptions) {
+    const queue = this.getQueue(name);
+    await queue.add(name, data, options);
+  }
+
+  async close() {
+    await Promise.all(
+      Array.from(this.workers.values()).map(async ({ worker, scheduler }) => {
+        await worker.close();
+        await scheduler.close();
+      })
+    );
+    this.workers.clear();
+
+    await Promise.all(Array.from(this.queues.values()).map((queue) => queue.close()));
+    this.queues.clear();
+
+    if (this.connection) {
+      await this.connection.quit();
+      this.connection = undefined;
+    }
+  }
+}

--- a/services/worker/src/queues/index.ts
+++ b/services/worker/src/queues/index.ts
@@ -1,0 +1,317 @@
+import mongoose, { Connection } from 'mongoose';
+import { JobsOptions } from 'bullmq';
+import pino from 'pino';
+import { BullQueueDriver, ProcessorFn } from './bull.js';
+
+export interface QueueDriver {
+  start(): Promise<void>;
+  registerProcessor<T>(queueName: string, processor: ProcessorFn<T>): void;
+  enqueue<T>(queueName: string, data: T, options?: JobsOptions): Promise<void>;
+  isReady(): boolean;
+  shutdown(): Promise<void>;
+}
+
+const logger = pino({ name: 'worker-queues', level: process.env.LOG_LEVEL ?? 'info' });
+
+class BullDriverAdapter implements QueueDriver {
+  private readonly driver: BullQueueDriver;
+  private ready = false;
+
+  constructor() {
+    this.driver = new BullQueueDriver({
+      defaultJobOptions: {
+        removeOnComplete: true,
+        removeOnFail: false,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 1000 },
+      },
+    });
+  }
+
+  async start(): Promise<void> {
+    try {
+      await this.driver.ping();
+      this.ready = true;
+      logger.info({ driver: 'bullmq' }, 'Connected to Redis queue backend');
+    } catch (error) {
+      this.ready = false;
+      logger.error({ err: error }, 'Failed to initialise BullMQ driver');
+      throw error;
+    }
+  }
+
+  registerProcessor<T>(queueName: string, processor: ProcessorFn<T>): void {
+    this.driver.registerProcessor(queueName, processor);
+  }
+
+  async enqueue<T>(queueName: string, data: T, options?: JobsOptions): Promise<void> {
+    await this.driver.enqueue(queueName, data, options);
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.driver.close();
+    this.ready = false;
+  }
+}
+
+interface OutboxDocument<T = unknown> {
+  queue: string;
+  payload: T;
+  state: 'pending' | 'processing' | 'completed' | 'failed';
+  attempts: number;
+  availableAt: Date;
+  createdAt: Date;
+  lastError?: string;
+}
+
+const outboxSchema = new mongoose.Schema<OutboxDocument>(
+  {
+    queue: { type: String, index: true, required: true },
+    payload: { type: mongoose.Schema.Types.Mixed, required: true },
+    state: { type: String, enum: ['pending', 'processing', 'completed', 'failed'], default: 'pending', index: true },
+    attempts: { type: Number, default: 0 },
+    availableAt: { type: Date, default: () => new Date() },
+    createdAt: { type: Date, default: () => new Date(), index: true },
+    lastError: { type: String },
+  },
+  { collection: 'worker_outbox' }
+);
+
+interface TimerHandle {
+  id: NodeJS.Timeout;
+}
+
+class MongoOutboxDriver implements QueueDriver {
+  private readonly processors = new Map<string, ProcessorFn>();
+  private readonly timers = new Map<string, TimerHandle>();
+  private readonly activeQueues = new Set<string>();
+  private connection?: Connection;
+  private model?: mongoose.Model<OutboxDocument>;
+  private ready = false;
+  constructor(private readonly pollIntervalMs = 1000) {}
+
+  private async ensureConnection(): Promise<void> {
+    if (this.connection) {
+      return;
+    }
+
+    const uri = process.env.MONGODB_URI;
+    if (!uri) {
+      throw new Error('MONGODB_URI must be defined when REDIS_URL is not set');
+    }
+
+    this.connection = await mongoose.createConnection(uri, {
+      maxPoolSize: 4,
+      minPoolSize: 1,
+    }).asPromise();
+
+    this.model = this.connection.model<OutboxDocument>('WorkerOutbox', outboxSchema);
+  }
+
+  private ensureTimer(queue: string) {
+    if (this.timers.has(queue)) {
+      return;
+    }
+
+    const timer: TimerHandle = {
+      id: setInterval(() => {
+        void this.drainQueue(queue);
+      }, this.pollIntervalMs),
+    };
+
+    this.timers.set(queue, timer);
+  }
+
+  async start(): Promise<void> {
+    try {
+      await this.ensureConnection();
+      this.ready = true;
+      logger.info({ driver: 'mongo-outbox' }, 'Connected to Mongo-backed outbox');
+      for (const queue of this.processors.keys()) {
+        this.ensureTimer(queue);
+      }
+    } catch (error) {
+      this.ready = false;
+      logger.error({ err: error }, 'Failed to initialise Mongo outbox driver');
+      throw error;
+    }
+  }
+
+  registerProcessor<T>(queueName: string, processor: ProcessorFn<T>): void {
+    this.processors.set(queueName, processor as ProcessorFn);
+    if (this.ready) {
+      this.ensureTimer(queueName);
+    }
+  }
+
+  async enqueue<T>(queueName: string, data: T, _options?: JobsOptions): Promise<void> {
+    await this.ensureConnection();
+    if (!this.model) {
+      throw new Error('Outbox model not initialised');
+    }
+
+    await this.model.create({
+      queue: queueName,
+      payload: data,
+      state: 'pending',
+      attempts: 0,
+      availableAt: new Date(),
+      createdAt: new Date(),
+    });
+  }
+
+  private async drainQueue(queueName: string) {
+    if (!this.ready || !this.model) {
+      return;
+    }
+
+    const processor = this.processors.get(queueName);
+    if (!processor) {
+      return;
+    }
+
+    if (this.activeQueues.has(queueName)) {
+      return;
+    }
+
+    this.activeQueues.add(queueName);
+
+    try {
+      let doc = await this.model.findOneAndUpdate(
+        {
+          queue: queueName,
+          state: 'pending',
+          availableAt: { $lte: new Date() },
+        },
+        {
+          $set: { state: 'processing' },
+          $inc: { attempts: 1 },
+        },
+        { sort: { createdAt: 1 }, returnDocument: 'after' }
+      );
+
+      while (doc) {
+        try {
+          await processor(doc.payload);
+          await this.model.updateOne({ _id: doc._id }, { $set: { state: 'completed', lastError: null } });
+        } catch (error) {
+          const delay = Math.min(60000, Math.pow(2, doc.attempts) * 1000);
+          await this.model.updateOne(
+            { _id: doc._id },
+            {
+              $set: {
+                state: 'pending',
+                availableAt: new Date(Date.now() + delay),
+                lastError: (error as Error).message,
+              },
+            }
+          );
+          logger.error({ queue: queueName, err: error }, 'Outbox job failed');
+        }
+
+        doc = await this.model.findOneAndUpdate(
+          {
+            queue: queueName,
+            state: 'pending',
+            availableAt: { $lte: new Date() },
+          },
+          {
+            $set: { state: 'processing' },
+            $inc: { attempts: 1 },
+          },
+          { sort: { createdAt: 1 }, returnDocument: 'after' }
+        );
+      }
+    } finally {
+      this.activeQueues.delete(queueName);
+    }
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async shutdown(): Promise<void> {
+    for (const timer of this.timers.values()) {
+      clearInterval(timer.id);
+    }
+    this.timers.clear();
+    this.activeQueues.clear();
+    this.ready = false;
+    if (this.connection) {
+      await this.connection.close();
+      this.connection = undefined;
+    }
+  }
+}
+
+class InMemoryDriver implements QueueDriver {
+  private readonly processors = new Map<string, ProcessorFn>();
+  private ready = false;
+
+  async start(): Promise<void> {
+    this.ready = true;
+    logger.warn('No REDIS_URL or MONGODB_URI found; using in-memory queue (non-persistent).');
+  }
+
+  registerProcessor<T>(queueName: string, processor: ProcessorFn<T>): void {
+    this.processors.set(queueName, processor as ProcessorFn);
+  }
+
+  async enqueue<T>(queueName: string, data: T, _options?: JobsOptions): Promise<void> {
+    const processor = this.processors.get(queueName);
+    if (!processor) {
+      throw new Error(`No processor registered for queue ${queueName}`);
+    }
+    await processor(data);
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async shutdown(): Promise<void> {
+    this.ready = false;
+    this.processors.clear();
+  }
+}
+
+export class QueueManager {
+  private driver: QueueDriver;
+
+  constructor() {
+    if (process.env.REDIS_URL) {
+      this.driver = new BullDriverAdapter();
+    } else if (process.env.MONGODB_URI) {
+      this.driver = new MongoOutboxDriver();
+    } else {
+      this.driver = new InMemoryDriver();
+    }
+  }
+
+  registerProcessor<T>(queueName: string, processor: ProcessorFn<T>): void {
+    this.driver.registerProcessor(queueName, processor);
+  }
+
+  async enqueue<T>(queueName: string, data: T, options?: JobsOptions): Promise<void> {
+    await this.driver.enqueue(queueName, data, options);
+  }
+
+  async start(): Promise<void> {
+    await this.driver.start();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.driver.shutdown();
+  }
+
+  isReady(): boolean {
+    return this.driver.isReady();
+  }
+}
+
+export const queueManager = new QueueManager();

--- a/services/worker/tsconfig.json
+++ b/services/worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a dedicated worker service with Express entrypoint, health endpoints, and queue manager supporting Redis, Mongo outbox, or in-memory fallback
- add BullMQ-based queue driver alongside Mongo-backed outbox implementation and baseline logging
- introduce worker-specific Dockerfile, TypeScript config, and repo-level npm scripts for building and running the worker

## Testing
- npm run worker:test

------
https://chatgpt.com/codex/tasks/task_e_68e398598dd883218a4f7493fcd1d0bd