### PR TITLE
chore(worker): move type packages to dependencies

### DIFF
--- a/services/worker/package.json
+++ b/services/worker/package.json
@@ -11,17 +11,17 @@
     "test": "echo \"No worker-specific tests yet\""
   },
   "dependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.9",
     "bullmq": "^4.17.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "ioredis": "^5.4.1",
     "mongoose": "^8.5.1",
-    "pino": "^9.1.0"
+    "pino": "^9.1.0",
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/node": "^20.14.9",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.5"
+    "ts-node-dev": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- move TypeScript and Express type packages from devDependencies into the worker service dependencies so Render installs them

## Testing
- npm install (fails: registry returned 403 for @types/express)
- npm run worker:build (fails: missing dependencies because install could not complete)

------
https://chatgpt.com/codex/tasks/task_e_68e3a3bb2b288321ba8ca87f7bb4fad0