### PR TITLE
Update worker TypeScript config for NodeNext resolution

### DIFF
--- a/services/worker/tsconfig.json
+++ b/services/worker/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "outDir": "dist",
     "rootDir": "src",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- switch the worker TypeScript compiler options to NodeNext module settings so node:http resolves under ESM

## Testing
- npm run worker:build *(fails: missing dependencies unavailable from npm registry in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a3c8b2988321b532c996757904ca