### PR TITLE
Fix mongoose connection options typing

### DIFF
--- a/services/worker/src/queues/index.ts
+++ b/services/worker/src/queues/index.ts
@@ -1,4 +1,4 @@
-import mongoose, { Connection } from 'mongoose';
+import mongoose, { Connection, type ConnectOptions } from 'mongoose';
 import { JobsOptions } from 'bullmq';
 import pino from 'pino';
 import { BullQueueDriver, ProcessorFn } from './bull.js';
@@ -104,10 +104,12 @@ class MongoOutboxDriver implements QueueDriver {
       throw new Error('MONGODB_URI must be defined when REDIS_URL is not set');
     }
 
-    this.connection = await mongoose.createConnection(uri, {
+    const options: ConnectOptions = {
       maxPoolSize: 4,
       minPoolSize: 1,
-    }).asPromise();
+    };
+
+    this.connection = await mongoose.createConnection(uri, options).asPromise();
 
     this.model = this.connection.model<OutboxDocument>('WorkerOutbox', outboxSchema);
   }


### PR DESCRIPTION
## Summary
- import the ConnectOptions type from mongoose in the worker queue module
- type the Mongo outbox connection options before creating the mongoose connection

## Testing
- npm run worker:build *(fails: missing npm registry access to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a40d6d88832186c5aa7cc09da179