### PR TITLE
Refactor document ingestion and analytics for document-first workflows

### DIFF
--- a/backend/data/documentCatalogue.js
+++ b/backend/data/documentCatalogue.js
@@ -5,29 +5,10 @@
 // the entire table rendering logic.
 
 const REQUIRED_DOCUMENTS = [
-  { key: 'proof_of_id',       label: 'Proof of ID',                                  cadence: { months: 60 } },
-  { key: 'proof_of_address',  label: 'Proof of Address',                             cadence: { months: 6 } },
-  { key: 'sa100_return_copy', label: 'SA100 Self Assessment (copy)',                 cadence: { yearlyBy: '01-31' } },
-  { key: 'sa302_tax_calc',    label: 'SA302 / Tax Calculation',                      cadence: { yearlyBy: '01-31' } },
-  { key: 'hmrc_statement',    label: 'HMRC Statement of Account',                    cadence: { yearlyBy: '01-31' } },
-  { key: 'p60',               label: 'P60 End of Year Certificate',                  cadence: { yearlyBy: '06-01' } },
-  { key: 'p11d',              label: 'P11D Benefits in Kind',                        cadence: { yearlyBy: '07-06' } },
-  { key: 'pension_statement', label: 'Pension Annual Statement (SIPP/Workplace)',    cadence: { yearlyBy: '06-30' } },
-  { key: 'pension_pia',       label: 'Pension Input Amounts (last 3 years)',         cadence: { yearlyBy: '06-30' } },
-  { key: 'interest_certs',    label: 'Bank/Building Society Interest Certificates',  cadence: { yearlyBy: '06-30' } },
-  { key: 'dividend_vouchers', label: 'Dividend Vouchers',                            cadence: { months: 12 } },
-  { key: 'broker_tax_pack',   label: 'Broker Annual Tax Pack / CTC',                 cadence: { yearlyBy: '06-30' } },
-  { key: 'trade_confirmations', label: 'Trade Confirmations / Contract Notes',       cadence: { months: 1 } },
-  { key: 'crypto_history',    label: 'Crypto Full Trade History (CSV/API)',          cadence: { months: 1 } },
-  { key: 'agent_statements',  label: 'Letting Agent Monthly Statements',             cadence: { months: 1 } },
-  { key: 'mortgage_interest', label: 'Annual Mortgage Interest Certificate',         cadence: { yearlyBy: '05-31' } },
-  { key: 'repairs_capital',   label: 'Repairs vs Capital Improvements Receipts',     cadence: { months: 1 } },
-  { key: 'purchase_completion', label: 'Purchase Completion Statement',              cadence: { adhoc: true } },
-  { key: 'sale_completion',   label: 'Sale Completion Statement',                    cadence: { adhoc: true } },
-  { key: 'sdlt_return',       label: 'SDLT Return & Calculation',                    cadence: { adhoc: true } },
-  { key: 'equity_grants',     label: 'RSU/ESPP/Option Grant Agreements & Schedules', cadence: { adhoc: true } },
-  { key: 'equity_events',     label: 'Vest/Exercise/Sell Confirmations',             cadence: { months: 1 } },
-  { key: 'gift_aid',          label: 'Gift Aid Donation Schedule & Receipts',        cadence: { months: 12 } },
+  { key: 'payslip',                   label: 'Payslip',                               cadence: { months: 1 } },
+  { key: 'current_account_statement', label: 'Current account statement',            cadence: { months: 1 } },
+  { key: 'pension_statement',         label: 'Pension contribution statement',       cadence: { yearlyBy: '04-30' } },
+  { key: 'hmrc_correspondence',       label: 'HMRC correspondence (SA302, notices)', cadence: { yearlyBy: '01-31' } },
 ];
 
 module.exports = {

--- a/backend/data/vaultCatalogue.js
+++ b/backend/data/vaultCatalogue.js
@@ -1,44 +1,81 @@
 // backend/data/vaultCatalogue.js
-// Canonical catalogue of UK tax documents (required + helpful) for vault integrations.
-// Shared between dashboard tooling and Scenario Lab document picker.
+// Canonical catalogue of documents used by the vault UI and downstream services.
 
 const DOCS = [
-  { key: 'proof_of_id',         label: 'Proof of ID',                                 cadence:{months:60},  why:'Verify identity (KYC/AML), protect account changes.', where:'Passport or DVLA Driving Licence.',                          required:true,  aliases:['passport','driving licence','driver licence','proof of id'] },
-  { key: 'proof_of_address',    label: 'Proof of Address',                            cadence:{months:6},   why:'Confirm UK residency for tax and correspondence.',     where:'Recent utility bill, bank/credit statement, council tax.',    required:true,  aliases:['utility bill','bank statement','proof of address'] },
-  { key: 'sa100_return_copy',   label: 'SA100 Self Assessment (copy)',                cadence:{yearlyBy:'01-31'}, why:'Record of filed return; carry-forwards, audit.',   where:'HMRC online → Self Assessment.',                               required:true,  aliases:['sa100','self assessment'] },
-  { key: 'sa302_tax_calc',      label: 'SA302 / Tax Calculation',                     cadence:{yearlyBy:'01-31'}, why:'Official calculation; supports mortgages/audit.',  where:'HMRC online → SA tax calculation.',                             required:true,  aliases:['sa302','tax calculation'] },
-  { key: 'hmrc_statement',      label: 'HMRC Statement of Account',                   cadence:{yearlyBy:'01-31'}, why:'Shows balancing payment & payments on account.',    where:'HMRC online → SA account.',                                     required:true,  aliases:['statement of account','hmrc statement'] },
-  { key: 'p60',                 label: 'P60 End of Year Certificate',                 cadence:{yearlyBy:'06-01'}, why:'Summary of pay & tax; essential for SA.',          where:'Employer/Payroll portal (by 31 May).',                         required:true,  aliases:['p60'] },
-  { key: 'p11d',                label: 'P11D Benefits in Kind',                       cadence:{yearlyBy:'07-06'}, why:'Taxable benefits (car, medical, etc.).',           where:'Employer/Payroll portal (by 6 July).',                         required:true,  aliases:['p11d'] },
-  { key: 'p45',                 label: 'P45 (leaver\'s certificate)',                 cadence:{adhoc:true},        why:'Pay/tax to date when leaving a job.',            where:'Provided by former employer.',                                  required:false, aliases:['p45'] },
-  { key: 'payslips',            label: 'Payslips (monthly)',                          cadence:{months:1},          why:'Reconcile vs bank & P60/P11D.',                  where:'Employer/Payroll portal.',                                      required:false, aliases:['payslip'] },
-  { key: 'pension_statement',   label: 'Pension Annual Statement (SIPP/Workplace)',   cadence:{yearlyBy:'06-30'},  why:'Tracks contributions (PIA) vs Annual Allowance.', where:'Pension provider portal/annual pack.',                          required:true,  aliases:['pension statement'] },
-  { key: 'pension_pia',         label: 'Pension Input Amounts (last 3 years)',        cadence:{yearlyBy:'06-30'},  why:'Needed for carry-forward and AA charges.',        where:'Pension schemes provide PIA per tax year.',                     required:true,  aliases:['pia','pension input amount'] },
-  { key: 'isa_statement',       label: 'ISA Annual Statement',                        cadence:{yearlyBy:'05-31'},  why:'Evidence of ISA subscriptions/limits.',           where:'ISA provider annual statement.',                                required:false, aliases:['isa statement'] },
-  { key: 'interest_certs',      label: 'Bank/Building Society Interest Certificates', cadence:{yearlyBy:'06-30'},  why:'Declare savings interest beyond PSA.',            where:'Bank portals (tax certificates) or statements.',                required:true,  aliases:['interest certificate','tax certificate'] },
-  { key: 'dividend_vouchers',   label: 'Dividend Vouchers',                           cadence:{months:12},         why:'Evidence of dividend income & withholding.',     where:'Broker portal or registrar.',                                   required:true,  aliases:['dividend voucher'] },
-  { key: 'broker_tax_pack',     label: 'Broker Annual Tax Pack / CTC',                cadence:{yearlyBy:'06-30'},  why:'Summarises dividends, interest & disposals.',    where:'Broker portal (HL, AJ Bell, IBKR, etc.).',                      required:true,  aliases:['tax pack','ctc','consolidated tax certificate'] },
-  { key: 'trade_confirmations', label: 'Trade Confirmations / Contract Notes',        cadence:{months:1},          why:'Evidence of acquisitions/disposals & fees.',     where:'Broker portal (PDF/CSV).',                                      required:true,  aliases:['contract note','trade confirmation'] },
-  { key: 'corp_actions',        label: 'Corporate Actions Evidence',                  cadence:{adhoc:true},        why:'Affects base cost (splits, rights, DRIP/scrip).', where:'Broker notices/registrar.',                                     required:false, aliases:['corporate action','drip','rights issue'] },
-  { key: 'crypto_history',      label: 'Crypto Full Trade History (CSV/API)',         cadence:{months:1},          why:'HMRC requires records; pooling; staking/airdrops.', where:'Exchange CSV/API; wallet explorers; tax tools.',               required:true,  aliases:['crypto history','exchange history','wallet history'] },
-  { key: 'tenancy_agreements',  label: 'Tenancy Agreements (AST)',                    cadence:{adhoc:true},        why:'Evidence of rental terms & periods let.',        where:'Lettings agent or signed AST.',                                 required:false, aliases:['tenancy agreement','ast'] },
-  { key: 'agent_statements',    label: 'Letting Agent Monthly Statements',            cadence:{months:1},          why:'Income/fees records for SA property pages.',     where:'Agent portal/email statements.',                                 required:true,  aliases:['agent statement','letting statement'] },
-  { key: 'mortgage_interest',   label: 'Annual Mortgage Interest Certificate',        cadence:{yearlyBy:'05-31'},  why:'Loan interest deduction evidence (rental).',     where:'Lender annual certificate.',                                     required:true,  aliases:['mortgage interest certificate'] },
-  { key: 'repairs_capital',     label: 'Repairs vs Capital Improvements Receipts',    cadence:{months:1},          why:'Split revenue vs capital for SA & future CGT.',  where:'Contractor invoices/receipts.',                                   required:true,  aliases:['repairs receipt','capital improvements'] },
-  { key: 'purchase_completion', label: 'Purchase Completion Statement',               cadence:{adhoc:true},        why:'Establishes base cost; incl. legal fees & SDLT.', where:'Conveyancer/solicitor pack.',                                   required:true,  aliases:['purchase completion statement','completion statement'] },
-  { key: 'sale_completion',     label: 'Sale Completion Statement',                   cadence:{adhoc:true},        why:'Proceeds & fees for CGT calculation.',           where:'Conveyancer/solicitor pack.',                                    required:true,  aliases:['sale completion statement'] },
-  { key: 'sdlt_return',         label: 'SDLT Return & Calculation',                   cadence:{adhoc:true},        why:'Confirms SDLT paid and rates used.',              where:'Conveyancer or HMRC SDLT copy.',                                 required:true,  aliases:['sdlt'] },
-  { key: 'equity_grants',       label: 'RSU/ESPP/Option Grant Agreements & Schedules', cadence:{adhoc:true},       why:'Defines vest/exercise terms; tax at vest.',       where:'Plan admin (Computershare/Equiniti/Fidelity).',                 required:true,  aliases:['grant agreement','equity grant'] },
-  { key: 'equity_events',       label: 'Vest/Exercise/Sell Confirmations',            cadence:{months:1},          why:'Taxed amounts at vest/exercise; basis updates.', where:'Plan/Broker statements.',                                        required:true,  aliases:['vest confirmation','exercise confirmation','sale confirmation'] },
-  { key: 'gift_aid',            label: 'Gift Aid Donation Schedule & Receipts',       cadence:{months:12},         why:'Gross-up claims in SA; higher rate relief.',      where:'Charity statements; CAF reports.',                               required:true,  aliases:['gift aid'] },
-  { key: 'gifts_log',           label: 'Gifts Log (7-year IHT tracking)',             cadence:{months:12},         why:'Track annual exemptions & PETs for IHT.',         where:'Self-maintained log with evidence.',                             required:false, aliases:['gifts log','iht log'] },
-  { key: 'student_loans',       label: 'Student/Postgrad Loan Statements',            cadence:{yearlyBy:'04-30'},  why:'Plan type and balance; check PAYE/SA deductions.', where:'SLC online account.',                                           required:false, aliases:['student loan statement','slc'] },
-  { key: 'child_benefit',       label: 'Child Benefit Award & Payments',              cadence:{months:12},         why:'Assess HICBC if income exceeds thresholds.',      where:'GOV.UK child benefit service.',                                  required:false, aliases:['child benefit'] },
-  { key: 'marriage_allowance',  label: 'Marriage Allowance Transfer Confirmation',    cadence:{yearlyBy:'01-31'},  why:'Impacts personal allowance transfer between spouses.', where:'GOV.UK marriage allowance service.',                         required:false, aliases:['marriage allowance'] }
+  {
+    key: 'payslip',
+    label: 'Payslip',
+    cadence: { months: 1 },
+    why: 'Confirms monthly earnings, deductions and pension contributions.',
+    where: 'Employer or payroll portal PDF export.',
+    required: true,
+    aliases: ['payslip', 'pay slip', 'salary slip'],
+    categories: ['required', 'analytics']
+  },
+  {
+    key: 'current_account_statement',
+    label: 'Current account statement',
+    cadence: { months: 1 },
+    why: 'Classifies income and spending for dashboards.',
+    where: 'Download monthly PDF/CSV statement from your bank.',
+    required: true,
+    aliases: ['bank statement', 'current account', 'checking statement'],
+    categories: ['required', 'analytics']
+  },
+  {
+    key: 'savings_account_statement',
+    label: 'Savings account statement',
+    cadence: { months: 1 },
+    why: 'Tracks savings balances, inflows and interest.',
+    where: 'Savings or cash ISA provider statements.',
+    required: false,
+    aliases: ['savings statement', 'saver statement'],
+    categories: ['analytics', 'helpful']
+  },
+  {
+    key: 'isa_statement',
+    label: 'ISA statement',
+    cadence: { yearlyBy: '04-30' },
+    why: 'Evidence ISA contributions and performance for wealth lab.',
+    where: 'Stocks & shares or cash ISA annual statement.',
+    required: false,
+    aliases: ['isa', 'isa annual statement'],
+    categories: ['analytics', 'helpful']
+  },
+  {
+    key: 'pension_statement',
+    label: 'Pension contribution statement',
+    cadence: { yearlyBy: '04-30' },
+    why: 'Provides pension input amounts for tax relief calculations.',
+    where: 'Workplace pension or SIPP provider.',
+    required: true,
+    aliases: ['pension statement', 'annual pension statement'],
+    categories: ['required', 'helpful']
+  },
+  {
+    key: 'hmrc_correspondence',
+    label: 'HMRC correspondence (SA302, statements, coding notices)',
+    cadence: { yearlyBy: '01-31' },
+    why: 'Supports tax lab balances and filing reminders.',
+    where: 'HMRC online account downloads.',
+    required: true,
+    aliases: ['sa302', 'tax calculation', 'hmrc statement'],
+    categories: ['required']
+  },
+  {
+    key: 'supporting_receipts',
+    label: 'Supporting receipts & schedules',
+    cadence: { months: 1 },
+    why: 'Additional context for deductions, expenses and scenario planning.',
+    where: 'Upload scans or CSV exports of relevant receipts.',
+    required: false,
+    aliases: ['receipt', 'schedule', 'expense receipt'],
+    categories: ['helpful']
+  }
 ];
 
 module.exports = {
   DOCS,
-  requiredDocs: DOCS.filter(d => d.required),
-  helpfulDocs: DOCS.filter(d => !d.required)
+  requiredDocs: DOCS.filter((d) => d.required),
+  helpfulDocs: DOCS.filter((d) => !d.required),
 };

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -128,14 +128,21 @@ const UserSchema = new mongoose.Schema({
     documentsUploaded:   { type: Number, default: 0 },
     documentsRequiredMet:{ type: Number, default: 0 },
     documentsHelpfulMet: { type: Number, default: 0 },
+    documentsAnalyticsMet: { type: Number, default: 0 },
+    documentsRequiredCompleted: { type: Number, default: 0 },
+    documentsHelpfulCompleted: { type: Number, default: 0 },
+    documentsAnalyticsCompleted: { type: Number, default: 0 },
     documentsRequiredTotal: { type: Number, default: 0 },
     documentsHelpfulTotal:  { type: Number, default: 0 },
+    documentsAnalyticsTotal: { type: Number, default: 0 },
     documentsProgressUpdatedAt: { type: Date, default: null },
     documentsCatalogue: { type: mongoose.Schema.Types.Mixed, default: {} },
     moneySavedEstimate:  { type: Number, default: 0 },
     hmrcFilingsComplete: { type: Number, default: 0 },
     minutesActive:       { type: Number, default: 0 }
   },
+
+  documentInsights: { type: mongoose.Schema.Types.Mixed, default: {} },
 
   salaryNavigator: { type: SalaryNavigatorSchema, default: () => ({}) },
   wealthPlan:      { type: WealthPlanSchema, default: () => ({}) },

--- a/backend/src/services/documents/catalogue.js
+++ b/backend/src/services/documents/catalogue.js
@@ -1,41 +1,76 @@
 const catalogue = [
-  { key: 'proof_of_id', label: 'Proof of ID', cadence: { months: 60 }, why: 'Verify identity (KYC/AML), protect account changes.', where: 'Passport or DVLA Driving Licence.', required: true },
-  { key: 'proof_of_address', label: 'Proof of Address', cadence: { months: 6 }, why: 'Confirm UK residency for tax and correspondence.', where: 'Recent utility bill, bank/credit statement, council tax.', required: true },
-  { key: 'sa100_return_copy', label: 'SA100 Self Assessment (copy)', cadence: { yearlyBy: '01-31' }, why: 'Record of filed return; carry-forwards, audit.', where: 'HMRC online → Self Assessment.', required: true },
-  { key: 'sa302_tax_calc', label: 'SA302 / Tax Calculation', cadence: { yearlyBy: '01-31' }, why: 'Official calculation; supports mortgages/audit.', where: 'HMRC online → SA tax calculation.', required: true },
-  { key: 'hmrc_statement', label: 'HMRC Statement of Account', cadence: { yearlyBy: '01-31' }, why: 'Shows balancing payment & payments on account.', where: 'HMRC online → SA account.', required: true },
-  { key: 'p60', label: 'P60 End of Year Certificate', cadence: { yearlyBy: '06-01' }, why: 'Summary of pay & tax; essential for SA.', where: 'Employer/Payroll portal (by 31 May).', required: true },
-  { key: 'p11d', label: 'P11D Benefits in Kind', cadence: { yearlyBy: '07-06' }, why: 'Taxable benefits (car, medical, etc.).', where: 'Employer/Payroll portal (by 6 July).', required: true },
-  { key: 'p45', label: "P45 (leaver's certificate)", cadence: { adhoc: true }, why: 'Pay/tax to date when leaving a job.', where: 'Provided by former employer.', required: false },
-  { key: 'payslips', label: 'Payslips (monthly)', cadence: { months: 1 }, why: 'Reconcile vs bank & P60/P11D.', where: 'Employer/Payroll portal.', required: false },
-  { key: 'pension_statement', label: 'Pension Annual Statement (SIPP/Workplace)', cadence: { yearlyBy: '06-30' }, why: 'Tracks contributions (PIA) vs Annual Allowance.', where: 'Pension provider portal/annual pack.', required: true },
-  { key: 'pension_pia', label: 'Pension Input Amounts (last 3 years)', cadence: { yearlyBy: '06-30' }, why: 'Needed for carry-forward and AA charges.', where: 'Pension schemes provide PIA per tax year.', required: true },
-  { key: 'isa_statement', label: 'ISA Annual Statement', cadence: { yearlyBy: '05-31' }, why: 'Evidence of ISA subscriptions/limits.', where: 'ISA provider annual statement.', required: false },
-  { key: 'interest_certs', label: 'Bank/Building Society Interest Certificates', cadence: { yearlyBy: '06-30' }, why: 'Declare savings interest beyond PSA.', where: 'Bank portals (tax certificates) or statements.', required: true },
-  { key: 'dividend_vouchers', label: 'Dividend Vouchers', cadence: { months: 12 }, why: 'Evidence of dividend income & withholding.', where: 'Broker portal or registrar.', required: true },
-  { key: 'broker_tax_pack', label: 'Broker Annual Tax Pack / CTC', cadence: { yearlyBy: '06-30' }, why: 'Summarises dividends, interest & disposals.', where: 'Broker portal (HL, AJ Bell, IBKR, etc.).', required: true },
-  { key: 'trade_confirmations', label: 'Trade Confirmations / Contract Notes', cadence: { months: 1 }, why: 'Evidence of acquisitions/disposals & fees.', where: 'Broker portal (PDF/CSV).', required: true },
-  { key: 'corp_actions', label: 'Corporate Actions Evidence', cadence: { adhoc: true }, why: 'Affects base cost (splits, rights, DRIP/scrip).', where: 'Broker notices/registrar.', required: false },
-  { key: 'crypto_history', label: 'Crypto Full Trade History (CSV/API)', cadence: { months: 1 }, why: 'HMRC requires records; pooling; staking/airdrops.', where: 'Exchange CSV/API; wallet explorers; tax tools.', required: true },
-  { key: 'tenancy_agreements', label: 'Tenancy Agreements (AST)', cadence: { adhoc: true }, why: 'Evidence of rental terms & periods let.', where: 'Lettings agent or signed AST.', required: false },
-  { key: 'agent_statements', label: 'Letting Agent Monthly Statements', cadence: { months: 1 }, why: 'Income/fees records for SA property pages.', where: 'Agent portal/email statements.', required: true },
-  { key: 'mortgage_interest', label: 'Annual Mortgage Interest Certificate', cadence: { yearlyBy: '05-31' }, why: 'Loan interest deduction evidence (rental).', where: 'Lender annual certificate.', required: true },
-  { key: 'repairs_capital', label: 'Repairs vs Capital Improvements Receipts', cadence: { months: 1 }, why: 'Split revenue vs capital for SA & future CGT.', where: 'Contractor invoices/receipts.', required: true },
-  { key: 'purchase_completion', label: 'Purchase Completion Statement', cadence: { adhoc: true }, why: 'Establishes base cost; incl. legal fees & SDLT.', where: 'Conveyancer/solicitor pack.', required: true },
-  { key: 'sale_completion', label: 'Sale Completion Statement', cadence: { adhoc: true }, why: 'Proceeds & fees for CGT calculation.', where: 'Conveyancer/solicitor pack.', required: true },
-  { key: 'sdlt_return', label: 'SDLT Return & Calculation', cadence: { adhoc: true }, why: 'Confirms SDLT paid and rates used.', where: 'Conveyancer or HMRC SDLT copy.', required: true },
-  { key: 'equity_grants', label: 'RSU/ESPP/Option Grant Agreements & Schedules', cadence: { adhoc: true }, why: 'Defines vest/exercise terms; tax at vest.', where: 'Plan admin (Computershare/Equiniti/Fidelity).', required: true },
-  { key: 'equity_events', label: 'Vest/Exercise/Sell Confirmations', cadence: { months: 1 }, why: 'Taxed amounts at vest/exercise; basis updates.', where: 'Plan/Broker statements.', required: true },
-  { key: 'gift_aid', label: 'Gift Aid Donation Schedule & Receipts', cadence: { months: 12 }, why: 'Gross-up claims in SA; higher rate relief.', where: 'Charity statements; CAF reports.', required: true },
-  { key: 'gifts_log', label: 'Gifts Log (7-year IHT tracking)', cadence: { months: 12 }, why: 'Track annual exemptions & PETs for IHT.', where: 'Self-maintained log with evidence.', required: false },
-  { key: 'student_loans', label: 'Student/Postgrad Loan Statements', cadence: { yearlyBy: '04-30' }, why: 'Plan type and balance; check PAYE/SA deductions.', where: 'SLC online account.', required: false },
-  { key: 'child_benefit', label: 'Child Benefit Award & Payments', cadence: { months: 12 }, why: 'Assess HICBC if income exceeds thresholds.', where: 'GOV.UK child benefit service.', required: false },
-  { key: 'marriage_allowance', label: 'Marriage Allowance Transfer Confirmation', cadence: { yearlyBy: '01-31' }, why: 'Impacts personal allowance transfer between spouses.', where: 'GOV.UK marriage allowance service.', required: false }
+  {
+    key: 'payslip',
+    label: 'Payslip',
+    cadence: { months: 1 },
+    why: 'Confirms earnings, tax, NI and pension deductions for salary analytics.',
+    where: 'Employer or payroll portal.',
+    categories: ['required', 'analytics']
+  },
+  {
+    key: 'current_account_statement',
+    label: 'Current account statement',
+    cadence: { months: 1 },
+    why: 'Used to classify spending, detect recurring commitments and reconcile income.',
+    where: 'Download PDF/CSV from your bank portal.',
+    categories: ['required', 'analytics']
+  },
+  {
+    key: 'savings_account_statement',
+    label: 'Savings account statement',
+    cadence: { months: 1 },
+    why: 'Tracks savings balances and interest for wealth and tax projections.',
+    where: 'Download from savings provider portal.',
+    categories: ['analytics', 'helpful']
+  },
+  {
+    key: 'isa_statement',
+    label: 'ISA statement',
+    cadence: { yearlyBy: '04-30' },
+    why: 'Confirms ISA subscriptions, allowances used and investment performance.',
+    where: 'ISA provider annual statement or monthly PDF.',
+    categories: ['analytics', 'helpful']
+  },
+  {
+    key: 'pension_statement',
+    label: 'Pension contribution statement',
+    cadence: { yearlyBy: '04-30' },
+    why: 'Tracks pension contributions, PIA and balances for tax relief planning.',
+    where: 'Workplace or SIPP provider annual statement.',
+    categories: ['required', 'helpful']
+  },
+  {
+    key: 'hmrc_correspondence',
+    label: 'HMRC correspondence (SA302, statements, coding notices)',
+    cadence: { yearlyBy: '01-31' },
+    why: 'Evidence for tax lab projections and liabilities.',
+    where: 'HMRC online account downloads.',
+    categories: ['required']
+  },
+  {
+    key: 'supporting_receipts',
+    label: 'Supporting receipts & schedules',
+    cadence: { months: 1 },
+    why: 'Additional context for deductions and scenario modelling.',
+    where: 'Upload scanned receipts or CSV exports.',
+    categories: ['helpful']
+  }
 ];
 
-const catalogueByKey = new Map(catalogue.map(item => [item.key, item]));
-const requiredKeys = catalogue.filter(item => item.required).map(item => item.key);
-const helpfulKeys = catalogue.filter(item => !item.required).map(item => item.key);
+const catalogueByKey = new Map(catalogue.map((item) => [item.key, item]));
+
+const categoryKeys = catalogue.reduce((acc, item) => {
+  const cats = Array.isArray(item.categories) && item.categories.length
+    ? item.categories
+    : ['helpful'];
+  for (const cat of cats) {
+    const key = String(cat || '').toLowerCase();
+    if (!key) continue;
+    if (!acc[key]) acc[key] = new Set();
+    acc[key].add(item.key);
+  }
+  return acc;
+}, {});
 
 function getCatalogue() {
   return catalogue;
@@ -45,12 +80,9 @@ function getCatalogueEntry(key) {
   return catalogueByKey.get(String(key || '')) || null;
 }
 
-function getRequiredKeys() {
-  return requiredKeys;
-}
-
-function getHelpfulKeys() {
-  return helpfulKeys;
+function getKeysByCategory(category) {
+  const key = String(category || '').toLowerCase();
+  return Array.from(categoryKeys[key] || []);
 }
 
 function summarizeCatalogue(perFileInput = {}) {
@@ -66,6 +98,7 @@ function summarizeCatalogue(perFileInput = {}) {
         uploadedAt: info.uploadedAt || null,
         name: info.name || null,
         size: Number.isFinite(info.size) ? info.size : Number(info.size) || 0,
+        categories: Array.isArray(info.categories) ? info.categories : undefined,
       };
     }
   }
@@ -79,6 +112,7 @@ function summarizeCatalogue(perFileInput = {}) {
       uploadedAt: info.uploadedAt,
       name: info.name,
       size: info.size,
+      categories: info.categories,
     });
     perKey[info.key] = entry;
   }
@@ -93,17 +127,30 @@ function summarizeCatalogue(perFileInput = {}) {
     entry.latestUploadedAt = entry.files[0]?.uploadedAt || null;
   }
 
-  const requiredCompleted = requiredKeys.filter(key => perKey[key]?.latestUploadedAt).length;
-  const helpfulCompleted = helpfulKeys.filter(key => perKey[key]?.latestUploadedAt).length;
+  const categorySummary = {};
+  for (const [cat, keys] of Object.entries(categoryKeys)) {
+    const list = Array.from(keys);
+    const completed = list.filter((key) => perKey[key]?.latestUploadedAt).length;
+    categorySummary[cat] = {
+      total: list.length,
+      completed,
+    };
+  }
 
-  return { perFile, perKey, requiredCompleted, helpfulCompleted };
+  return {
+    perFile,
+    perKey,
+    categories: categorySummary,
+    requiredCompleted: categorySummary.required?.completed || 0,
+    helpfulCompleted: categorySummary.helpful?.completed || 0,
+    analyticsCompleted: categorySummary.analytics?.completed || 0,
+  };
 }
 
 module.exports = {
   catalogue,
   getCatalogue,
   getCatalogueEntry,
-  getRequiredKeys,
-  getHelpfulKeys,
+  getKeysByCategory,
   summarizeCatalogue,
 };

--- a/backend/src/services/documents/ingest.js
+++ b/backend/src/services/documents/ingest.js
@@ -1,0 +1,177 @@
+const pdfParse = require('pdf-parse');
+
+function normalise(text) {
+  return String(text || '').toLowerCase();
+}
+
+async function extractText(buffer) {
+  if (!buffer || !buffer.length) return '';
+  try {
+    const parsed = await pdfParse(buffer);
+    if (parsed && typeof parsed.text === 'string') {
+      return parsed.text;
+    }
+  } catch (err) {
+    console.warn('[documents:ingest] pdf-parse failed, falling back to filename heuristics', err?.message || err);
+  }
+  return '';
+}
+
+function containsKeywords(text, keywords) {
+  const lower = normalise(text);
+  return keywords.some((k) => lower.includes(k));
+}
+
+function extractNumber(text, labels) {
+  const lower = normalise(text);
+  for (const label of labels) {
+    const idx = lower.indexOf(label);
+    if (idx === -1) continue;
+    const snippet = text.slice(Math.max(0, idx - 12), idx + 60);
+    const match = snippet.match(/(-?\d[\d,.]*)(?:\s*(?:£|gbp))?/i) || snippet.match(/£\s*(-?[\d,.]+)/i);
+    if (match) {
+      return Number(match[1].replace(/[,£\s]/g, ''));
+    }
+  }
+  return null;
+}
+
+function parseStatementTransactions(text) {
+  const lines = String(text || '').split(/\r?\n+/).map((l) => l.trim()).filter(Boolean);
+  const categories = {
+    income: ['salary', 'payroll', 'payslip', 'hmrc', 'bonus'],
+    housing: ['rent', 'mortgage'],
+    groceries: ['tesco', 'sainsbury', 'waitrose', 'aldi', 'lidl', 'morrison'],
+    subscriptions: ['netflix', 'spotify', 'prime', 'icloud', 'google'],
+    utilities: ['edf', 'octopus', 'british gas', 'thames water', 'ee', 'o2', 'vodafone'],
+    savings: ['transfer', 'savings', 'isa'],
+    shopping: ['amazon', 'apple', 'currys', 'argos'],
+  };
+  const transactions = [];
+  for (const line of lines) {
+    const amountMatch = line.match(/(-?£?\d[\d,]*\.?\d{0,2})$/);
+    if (!amountMatch) continue;
+    const amount = Number(amountMatch[1].replace(/[,£]/g, ''));
+    const description = line.replace(amountMatch[0], '').trim();
+    const descLower = normalise(description);
+    let category = 'other';
+    for (const [cat, probes] of Object.entries(categories)) {
+      if (probes.some((probe) => descLower.includes(probe))) {
+        category = cat;
+        break;
+      }
+    }
+    const direction = amount >= 0 ? 'inflow' : 'outflow';
+    transactions.push({ description, amount, category, direction });
+  }
+  const totals = transactions.reduce((acc, tx) => {
+    if (tx.direction === 'inflow') acc.income += tx.amount;
+    else acc.spend += Math.abs(tx.amount);
+    return acc;
+  }, { income: 0, spend: 0 });
+  return { transactions, totals };
+}
+
+function summariseTransactions(transactions) {
+  const groups = {};
+  for (const tx of transactions) {
+    const key = tx.category || 'other';
+    if (!groups[key]) groups[key] = { category: key, inflow: 0, outflow: 0 };
+    if (tx.direction === 'inflow') groups[key].inflow += tx.amount;
+    else groups[key].outflow += Math.abs(tx.amount);
+  }
+  return Object.values(groups).sort((a, b) => (b.outflow || b.inflow) - (a.outflow || a.inflow));
+}
+
+function buildInsights(entry, text) {
+  const key = entry.key;
+  const insights = { key, metrics: {}, narrative: [] };
+
+  if (key === 'payslip') {
+    const gross = extractNumber(text, ['gross pay', 'total gross']);
+    const net = extractNumber(text, ['net pay', 'take home']);
+    const tax = extractNumber(text, ['tax', 'income tax']);
+    const ni = extractNumber(text, ['national insurance']);
+    const pension = extractNumber(text, ['pension', 'employee pension']);
+    insights.metrics = {
+      gross,
+      net,
+      tax,
+      ni,
+      pension,
+    };
+    insights.narrative.push('Earnings and deductions extracted from payslip.');
+  } else if (key === 'current_account_statement') {
+    const parsed = parseStatementTransactions(text);
+    insights.transactions = parsed.transactions;
+    insights.metrics = {
+      income: parsed.totals.income,
+      spend: parsed.totals.spend,
+      categories: summariseTransactions(parsed.transactions),
+    };
+    insights.narrative.push('Classified inflows and outflows from current account statement.');
+  } else if (key === 'savings_account_statement' || key === 'isa_statement') {
+    const balance = extractNumber(text, ['balance', 'closing balance']);
+    const interest = extractNumber(text, ['interest', 'gross interest']);
+    insights.metrics = {
+      balance,
+      interest,
+    };
+    insights.narrative.push('Updated balances from savings/ISA statement.');
+  } else if (key === 'pension_statement') {
+    const contributions = extractNumber(text, ['contribution', 'total contributions']);
+    const balance = extractNumber(text, ['plan value', 'current value']);
+    insights.metrics = {
+      contributions,
+      balance,
+    };
+    insights.narrative.push('Pension contribution and balance captured.');
+  } else if (key === 'hmrc_correspondence') {
+    const taxDue = extractNumber(text, ['tax due', 'balance outstanding']);
+    insights.metrics = { taxDue };
+    insights.narrative.push('HMRC correspondence ingested for tax lab.');
+  } else if (key === 'supporting_receipts') {
+    insights.narrative.push('Supporting evidence stored for manual review.');
+  }
+
+  return insights;
+}
+
+function validateDocument(entry, text, originalName) {
+  const lowerName = normalise(originalName);
+  switch (entry.key) {
+    case 'payslip':
+      return containsKeywords(text, ['payslip', 'gross pay', 'net pay']) || containsKeywords(lowerName, ['payslip']);
+    case 'current_account_statement':
+      return containsKeywords(text, ['statement', 'account number']) || containsKeywords(lowerName, ['statement']);
+    case 'savings_account_statement':
+      return containsKeywords(text, ['savings', 'statement']) || containsKeywords(lowerName, ['savings']);
+    case 'isa_statement':
+      return containsKeywords(text, ['isa', 'individual savings']) || containsKeywords(lowerName, ['isa']);
+    case 'pension_statement':
+      return containsKeywords(text, ['pension', 'contribution']) || containsKeywords(lowerName, ['pension']);
+    case 'hmrc_correspondence':
+      return containsKeywords(text, ['hm revenue', 'sa302', 'tax calculation']) || containsKeywords(lowerName, ['hmrc', 'sa302']);
+    case 'supporting_receipts':
+      return true;
+    default:
+      return false;
+  }
+}
+
+async function analyseDocument(entry, buffer, originalName) {
+  const text = await extractText(buffer);
+  const valid = validateDocument(entry, text, originalName);
+  if (!valid) {
+    return { valid: false, reason: `Uploaded file does not look like ${entry.label.toLowerCase()}.` };
+  }
+  return {
+    valid: true,
+    insights: buildInsights(entry, text),
+    text,
+  };
+}
+
+module.exports = {
+  analyseDocument,
+};

--- a/backend/src/services/documents/insightsStore.js
+++ b/backend/src/services/documents/insightsStore.js
@@ -1,0 +1,106 @@
+const User = require('../../../models/User');
+
+function mergeFileReference(existing = [], fileInfo) {
+  const filtered = existing.filter((item) => item.id !== fileInfo.id);
+  filtered.unshift({
+    id: fileInfo.id,
+    name: fileInfo.name,
+    uploadedAt: fileInfo.uploadedAt,
+  });
+  return filtered.slice(0, 5);
+}
+
+function buildAggregates(sources) {
+  const aggregates = {
+    income: {},
+    cashflow: {},
+    savings: {},
+    pension: {},
+    tax: {},
+  };
+
+  const payslip = sources.payslip;
+  if (payslip?.metrics) {
+    aggregates.income = {
+      gross: payslip.metrics.gross ?? null,
+      net: payslip.metrics.net ?? null,
+      tax: payslip.metrics.tax ?? null,
+      ni: payslip.metrics.ni ?? null,
+      pension: payslip.metrics.pension ?? null,
+    };
+  }
+
+  const currentAccount = sources.current_account_statement;
+  if (currentAccount?.metrics) {
+    aggregates.cashflow = {
+      income: currentAccount.metrics.income ?? 0,
+      spend: currentAccount.metrics.spend ?? 0,
+      categories: currentAccount.metrics.categories || [],
+    };
+  }
+
+  const savingsBalance = [];
+  if (sources.savings_account_statement?.metrics?.balance != null) {
+    savingsBalance.push(sources.savings_account_statement.metrics.balance);
+  }
+  if (sources.isa_statement?.metrics?.balance != null) {
+    savingsBalance.push(sources.isa_statement.metrics.balance);
+  }
+  if (savingsBalance.length) {
+    aggregates.savings = {
+      balance: savingsBalance.reduce((acc, v) => acc + (Number(v) || 0), 0),
+      interest: sources.savings_account_statement?.metrics?.interest ?? null,
+    };
+  }
+
+  if (sources.pension_statement?.metrics) {
+    aggregates.pension = {
+      balance: sources.pension_statement.metrics.balance ?? null,
+      contributions: sources.pension_statement.metrics.contributions ?? null,
+    };
+  }
+
+  if (sources.hmrc_correspondence?.metrics?.taxDue != null) {
+    aggregates.tax = {
+      taxDue: sources.hmrc_correspondence.metrics.taxDue,
+    };
+  }
+
+  return aggregates;
+}
+
+async function applyDocumentInsights(userId, key, insights, fileInfo) {
+  if (!userId || !key || !insights) return null;
+  const doc = await User.findById(userId, 'documentInsights').lean();
+  const current = doc?.documentInsights || {};
+  const sources = { ...(current.sources || {}) };
+  const existing = sources[key] || {};
+  sources[key] = {
+    ...existing,
+    key,
+    metrics: insights.metrics || existing.metrics || {},
+    narrative: insights.narrative || existing.narrative || [],
+    transactions: insights.transactions || existing.transactions || [],
+    files: mergeFileReference(existing.files, fileInfo),
+  };
+
+  const newState = {
+    sources,
+    aggregates: buildAggregates(sources),
+    updatedAt: new Date(),
+  };
+
+  await User.findByIdAndUpdate(userId, {
+    $set: {
+      documentInsights: newState,
+    },
+  }).exec().catch((err) => {
+    console.warn('[documents:insightsStore] failed to persist insights', err);
+  });
+
+  return newState;
+}
+
+module.exports = {
+  applyDocumentInsights,
+};

--- a/frontend/compensation.html
+++ b/frontend/compensation.html
@@ -197,7 +197,7 @@
             <button class="btn btn-outline-secondary" id="comp-run-benchmark"><i class="bi bi-graph-up"></i> Refresh benchmarks</button>
           </div>
           <div id="comp-benchmark-results" class="row g-3"></div>
-          <div class="alert alert-light border mt-3" id="comp-benchmark-help">Connect your integrations to pull real-time salary data from HMRC, recruitment APIs and payscale sources.</div>
+          <div class="alert alert-light border mt-3" id="comp-benchmark-help">Upload payslips and compensation letters in the document vault to benchmark your earnings in real time.</div>
         </div>
       </div>
     </section>

--- a/frontend/document-vault.html
+++ b/frontend/document-vault.html
@@ -94,10 +94,14 @@
     .doc-progress-meta{ color: var(--muted); font-size:.85rem; }
     #doc-progress-updated{ color: var(--muted); font-size:.85rem; }
 
-    .doc-table tbody tr{ transition: background-color .15s ease; }
-    .doc-table tbody tr:hover{ background: rgba(111,66,193,.05); }
-    .doc-table .doc-why,
-    .doc-table .doc-where{ min-width: 180px; max-width: 240px; }
+    .doc-accordion{ display:flex; flex-direction:column; gap:10px; }
+    .doc-accordion details{ border:1px solid var(--bs-border-color); border-radius:12px; background: var(--bs-body-bg); box-shadow:var(--tile-shadow); padding:12px 14px; }
+    .doc-accordion summary{ font-weight:600; cursor:pointer; display:flex; flex-wrap:wrap; align-items:center; gap:10px; list-style:none; }
+    .doc-accordion summary::-webkit-details-marker{ display:none; }
+    .doc-accordion .doc-meta{ color: var(--muted); font-size:.85rem; display:flex; flex-wrap:wrap; gap:14px; }
+    .doc-accordion .doc-meta span{ display:flex; align-items:center; gap:6px; }
+    .doc-accordion .doc-body{ margin-top:10px; font-size:.9rem; color: var(--muted); }
+    .doc-accordion .doc-actions{ margin-top:12px; display:flex; gap:10px; flex-wrap:wrap; }
 
     .doc-files-panel{ border:1px solid var(--bs-border-color); border-radius:12px; padding:12px; background: var(--bs-body-bg); box-shadow: var(--tile-shadow); }
     .doc-files-panel table{ margin-bottom:0; }
@@ -167,26 +171,20 @@
             </div>
             <div class="doc-progress-meta">Extras that accelerate advice and prep.</div>
           </div>
+          <div class="doc-progress-card">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+              <span class="fw-semibold">Analytics</span>
+              <span id="doc-progress-analytics-count" class="doc-progress-meta">0 / 0</span>
+            </div>
+            <div class="progress mb-1">
+              <div id="doc-progress-analytics-bar" class="progress-bar bg-info" style="width:0%"></div>
+            </div>
+            <div class="doc-progress-meta">Fuel dashboards and labs with source data.</div>
+          </div>
         </div>
 
-        <div class="table-responsive mb-3">
-          <table class="table table-hover align-middle doc-table">
-            <thead class="table-light">
-              <tr>
-                <th>Document</th>
-                <th>Required?</th>
-                <th>Status</th>
-                <th>Last uploaded</th>
-                <th>Next due</th>
-                <th class="doc-why">Why we need it</th>
-                <th class="doc-where">Where to find it</th>
-                <th class="text-end">Actions</th>
-              </tr>
-            </thead>
-            <tbody id="doc-catalogue-body">
-              <tr><td colspan="8" class="text-muted small">Loading…</td></tr>
-            </tbody>
-          </table>
+        <div class="doc-accordion" id="doc-catalogue-body">
+          <div class="text-muted small">Loading…</div>
         </div>
         <div id="doc-catalogue-msg" class="small text-muted"></div>
 
@@ -203,11 +201,11 @@
                   <th>Uploaded</th>
                   <th>Size</th>
                   <th>Collection</th>
-                  <th class="text-end">Actions</th>
+                  <th class="text-end">Manage</th>
                 </tr>
               </thead>
               <tbody id="doc-files-table-body">
-                <tr><td colspan="5" class="text-muted small">Select a document to preview uploads.</td></tr>
+                <tr><td colspan="5" class="text-muted small">Select a document to see uploads. Manage previews or deletions from the collections panel.</td></tr>
               </tbody>
             </table>
           </div>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -23,10 +23,10 @@
     <div id="dashboard-empty-state" class="alert alert-warning border border-warning-subtle d-none" role="alert">
       <div class="d-flex flex-wrap align-items-center gap-3">
         <div>
-          <strong>No data</strong> — set up your integrations to get started.
-          <div class="small text-muted">Connect your bank feeds and HMRC portal from the integrations hub in your profile.</div>
+          <strong>No data</strong> — upload your core documents to get started.
+          <div class="small text-muted">Add payslips, bank and savings statements, ISA summaries and more from the document vault.</div>
         </div>
-        <a class="btn btn-sm btn-outline-primary ms-auto" href="/profile.html#integrations">Open integrations</a>
+        <a class="btn btn-sm btn-outline-primary ms-auto" href="/document-vault.html">Open document vault</a>
       </div>
     </div>
 
@@ -86,7 +86,7 @@
         </div>
 
         <div id="ai-suggestions" class="row g-3 mt-3"></div>
-        <div id="ai-suggestions-empty" class="text-muted small mt-3">Insights will appear here once your integrations are connected.</div>
+        <div id="ai-suggestions-empty" class="text-muted small mt-3">Insights will appear here once you upload supporting documents.</div>
       </div>
     </section>
 
@@ -101,7 +101,7 @@
 
       <div class="row g-3 mb-3">
         <div class="col-12 col-md-6 col-xl-3">
-          <div class="card h-100 shadow-sm">
+          <div class="card h-100 shadow-sm" data-metric-card>
             <div class="card-body">
               <div class="text-muted small">Savings capacity</div>
               <div class="h4 m-0" id="kpi-savings">£—</div>
@@ -111,7 +111,7 @@
           </div>
         </div>
         <div class="col-12 col-md-6 col-xl-3">
-          <div class="card h-100 shadow-sm">
+          <div class="card h-100 shadow-sm" data-metric-card>
             <div class="card-body">
               <div class="text-muted small">HMRC balance</div>
               <div class="h4 m-0" id="kpi-hmrc">—</div>
@@ -120,7 +120,7 @@
           </div>
         </div>
         <div class="col-12 col-md-6 col-xl-3">
-          <div class="card h-100 shadow-sm">
+          <div class="card h-100 shadow-sm" data-metric-card>
             <div class="card-body">
               <div class="text-muted small">Gross income</div>
               <div class="h4 m-0" id="kpi-income">£—</div>
@@ -129,7 +129,7 @@
           </div>
         </div>
         <div class="col-12 col-md-6 col-xl-3">
-          <div class="card h-100 shadow-sm">
+          <div class="card h-100 shadow-sm" data-metric-card>
             <div class="card-body">
               <div class="text-muted small">Total spend</div>
               <div class="h4 m-0" id="kpi-spend">£—</div>
@@ -263,7 +263,7 @@
                   <canvas id="fp-networth-chart" height="160"></canvas>
                 </div>
               </div>
-              <div class="alert alert-light border mt-3 d-none" id="fp-networth-empty">No data — set up your integrations to get started.</div>
+              <div class="alert alert-light border mt-3 d-none" id="fp-networth-empty">No data — upload recent documents to get started.</div>
             </div>
           </div>
         </div>

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -343,7 +343,7 @@
     if (!el) return;
     if (!metric) {
       el.textContent = '—';
-      if (opts.subId) setText(opts.subId, 'No data — set up your integrations to get started.');
+      if (opts.subId) setText(opts.subId, 'No data — upload documents in the vault to get started.');
       if (opts.deltaId) setText(opts.deltaId, '');
       return;
     }
@@ -354,6 +354,15 @@
     if (opts.deltaId) setText(opts.deltaId, formatDelta(metric.delta, metric.deltaMode));
     if (opts.noteId) setText(opts.noteId, metric.note || '');
     if (opts.subtleId) setText(opts.subtleId, metric.subtle || '');
+
+    const card = el.closest('[data-metric-card]');
+    if (card) {
+      if (metric.sourceNote) {
+        card.setAttribute('title', metric.sourceNote);
+      } else {
+        card.removeAttribute('title');
+      }
+    }
   }
 
   function formatDelta(delta, mode) {
@@ -474,7 +483,7 @@
     container.innerHTML = '';
     const entries = Array.isArray(gauges) ? gauges : [];
     if (!entries.length) {
-      container.innerHTML = '<div class="col-12 text-muted small">No data — set up your integrations to get started.</div>';
+      container.innerHTML = '<div class="col-12 text-muted small">No data — upload documents in the vault to get started.</div>';
       return;
     }
     entries.forEach((g) => {
@@ -587,7 +596,7 @@
 
     if (!combined.length) {
       empty?.classList.remove('d-none');
-      empty.textContent = hasData ? 'No upcoming events yet.' : 'No data — set up your integrations to get started.';
+      empty.textContent = hasData ? 'No upcoming events yet.' : 'No data — upload documents in the vault to get started.';
       return;
     }
     empty?.classList.add('d-none');

--- a/frontend/js/tax-lab.js
+++ b/frontend/js/tax-lab.js
@@ -189,18 +189,19 @@
       return;
     }
     wrap.innerHTML = '';
-    docs.forEach((doc) => {
-      const div = document.createElement('div');
-      div.className = `doc-status ${doc.status}`;
-      div.innerHTML = `
-        <div>
-          <div class="label">${escapeHtml(doc.label)}</div>
+      docs.forEach((doc) => {
+        const div = document.createElement('div');
+        div.className = `doc-status ${doc.status}`;
+        div.innerHTML = `
+          <div>
+            <div class="label">${escapeHtml(doc.label)}</div>
           <div class="small text-muted">${doc.lastUploadedAt ? `Last uploaded ${formatDate(doc.lastUploadedAt)}` : 'No upload yet'}</div>
-        </div>
-        <span class="badge bg-${badgeFromStatus(doc.status)}">${statusLabel(doc.status)}</span>
-      `;
-      wrap.appendChild(div);
-    });
+          ${doc.sourceNote ? `<div class="small text-muted">Sources: ${escapeHtml(doc.sourceNote)}</div>` : ''}
+          </div>
+          <span class="badge bg-${badgeFromStatus(doc.status)}">${statusLabel(doc.status)}</span>
+        `;
+        wrap.appendChild(div);
+      });
   }
 
   function renderScenarios() {


### PR DESCRIPTION
## Summary
- rework the document catalogue around required, helpful, and analytics-source categories with non-deletable default collections
- add a document ingestion service that validates uploads, extracts insights, and stores document-driven metrics for dashboards, tax lab, and wealth lab
- refresh the document vault UI with collapsible checklist entries, analytics progress, and automatic routing of uploads to default collections while updating copy to emphasise document uploads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e090410c8321b546c7eae4c149c6