### PR TITLE
Implement document insight pipeline and dashboard range comparisons

### DIFF
--- a/backend/models/DocumentInsight.js
+++ b/backend/models/DocumentInsight.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const DocumentInsightSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true, required: true },
+  fileId: { type: String, index: true, required: true },
+  catalogueKey: { type: String, index: true, required: true },
+  baseKey: { type: String, index: true, required: true },
+  documentMonth: { type: String, index: true, default: null },
+  documentDate: { type: Date, default: null },
+  documentLabel: { type: String, default: null },
+  documentName: { type: String, default: null },
+  nameMatchesUser: { type: Boolean, default: null },
+  extractedAt: { type: Date, default: Date.now },
+  metrics: { type: mongoose.Schema.Types.Mixed, default: {} },
+  metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+  transactions: { type: [mongoose.Schema.Types.Mixed], default: [] },
+  narrative: { type: [String], default: [] },
+}, { timestamps: true });
+
+DocumentInsightSchema.index({ userId: 1, catalogueKey: 1, documentMonth: 1 });
+DocumentInsightSchema.index({ userId: 1, fileId: 1 }, { unique: true });
+
+module.exports = mongoose.model('DocumentInsight', DocumentInsightSchema);

--- a/backend/src/services/documents/ingest.js
+++ b/backend/src/services/documents/ingest.js
@@ -1,4 +1,5 @@
 const pdfParse = require('pdf-parse');
+const dayjs = require('dayjs');
 const { analysePayslip } = require('./parsers/payslip');
 const { analyseCurrentAccountStatement } = require('./parsers/statement');
 
@@ -41,10 +42,69 @@ function extractNumber(text, labels) {
   return null;
 }
 
+function normaliseName(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function buildUserNameSet(user = {}) {
+  const names = new Set();
+  const add = (value) => {
+    const norm = normaliseName(value);
+    if (norm) names.add(norm);
+  };
+  if (user.fullName) add(user.fullName);
+  if (user.preferredName) add(user.preferredName);
+  if (user.firstName) add(user.firstName);
+  if (user.lastName) add(user.lastName);
+  if (user.firstName && user.lastName) add(`${user.firstName} ${user.lastName}`);
+  if (user.username) add(user.username);
+  if (Array.isArray(user.aliases)) {
+    user.aliases.forEach(add);
+  }
+  return names;
+}
+
+function nameMatchesUser(candidate, userSet) {
+  const norm = normaliseName(candidate);
+  if (!norm || !userSet.size) return null;
+  if (userSet.has(norm)) return true;
+  for (const stored of userSet) {
+    const tokens = stored.split(' ').filter(Boolean);
+    if (tokens.length && tokens.every((token) => norm.includes(token))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function firstValidDate(...values) {
+  for (const value of values) {
+    if (!value) continue;
+    const parsed = dayjs(value);
+    if (parsed.isValid()) return parsed;
+  }
+  return null;
+}
+
 async function buildInsights(entry, text, context = {}) {
   const key = entry.key;
   const insights = { key, metrics: {}, narrative: [] };
   const originalName = context.originalName || null;
+  const userNames = buildUserNameSet(context.user || {});
+
+  function stampDocumentDate(target, dateValue) {
+    const parsed = firstValidDate(dateValue);
+    if (!parsed) return null;
+    const iso = parsed.toISOString();
+    target.metadata = target.metadata || {};
+    target.metadata.documentDate = iso;
+    target.metadata.documentMonth = parsed.format('YYYY-MM');
+    target.metadata.documentMonthLabel = parsed.format('MM/YYYY');
+    return iso;
+  }
 
   if (key === 'payslip') {
     const breakdown = await analysePayslip(text || '');
@@ -58,6 +118,8 @@ async function buildInsights(entry, text, context = {}) {
       periodStart: breakdown.periodStart || null,
       periodEnd: breakdown.periodEnd || null,
       extractionSource: breakdown.extractionSource || null,
+      personName: breakdown.employeeName || null,
+      employerName: breakdown.employerName || null,
     };
     insights.metrics = {
       gross: breakdown.gross ?? null,
@@ -86,6 +148,15 @@ async function buildInsights(entry, text, context = {}) {
       periodStart: breakdown.periodStart || null,
       periodEnd: breakdown.periodEnd || null,
     };
+    const documentIso = stampDocumentDate(insights, breakdown.payDate || breakdown.periodEnd || breakdown.periodStart || null);
+    if (breakdown.employeeName) {
+      const matches = nameMatchesUser(breakdown.employeeName, userNames);
+      insights.metadata.documentName = breakdown.employeeName;
+      insights.metadata.nameMatchesUser = matches;
+    }
+    if (!insights.metadata.documentDate && documentIso) {
+      insights.metadata.documentDate = documentIso;
+    }
     if (insights.metrics.notes.length) {
       insights.narrative.push(...insights.metrics.notes);
     } else {
@@ -129,6 +200,22 @@ async function buildInsights(entry, text, context = {}) {
       extractionSource: analysed.extractionSource || null,
       account: metadata,
     };
+    const docDate = firstValidDate(metadata.period?.end, metadata.period?.start, transactions[0]?.date);
+    if (docDate) {
+      insights.metadata = insights.metadata || {};
+      insights.metadata.documentDate = docDate.toISOString();
+      insights.metadata.documentMonth = docDate.format('YYYY-MM');
+      insights.metadata.documentMonthLabel = docDate.format('MM/YYYY');
+    }
+    if (metadata.accountHolder) {
+      const match = nameMatchesUser(metadata.accountHolder, userNames);
+      insights.metadata.documentName = metadata.accountHolder;
+      insights.metadata.nameMatchesUser = match;
+      insights.metadata.accountHolder = metadata.accountHolder;
+    }
+    if (!Array.isArray(insights.metadata.statementPeriods)) {
+      insights.metadata.statementPeriods = metadata.period ? [metadata.period] : [];
+    }
     const accountLabel = [metadata.accountName, metadata.accountNumberMasked].filter(Boolean).join(' ');
     insights.narrative.push(accountLabel
       ? `Classified inflows and outflows for ${accountLabel}.`
@@ -185,7 +272,7 @@ function validateDocument(entry, text, originalName) {
   }
 }
 
-async function analyseDocument(entry, buffer, originalName) {
+async function analyseDocument(entry, buffer, originalName, context = {}) {
   const text = await extractText(buffer);
   const valid = validateDocument(entry, text, originalName);
   if (!valid) {
@@ -193,7 +280,7 @@ async function analyseDocument(entry, buffer, originalName) {
   }
   return {
     valid: true,
-    insights: await buildInsights(entry, text, { originalName }),
+    insights: await buildInsights(entry, text, { ...context, originalName }),
     text,
   };
 }

--- a/backend/src/services/documents/parsers/payslip.js
+++ b/backend/src/services/documents/parsers/payslip.js
@@ -201,6 +201,8 @@ async function llmPayslipExtraction(text) {
         payment_date: { type: ['string', 'null'] },
         period_start: { type: ['string', 'null'] },
         period_end: { type: ['string', 'null'] },
+        employee_name: { type: ['string', 'null'] },
+        employer_name: { type: ['string', 'null'] },
       },
     },
     strict: true,
@@ -232,6 +234,8 @@ ${text.slice(0, 6000)}`;
     payDate: parseDate(response.payment_date) || null,
     periodStart: parseDate(response.period_start) || null,
     periodEnd: parseDate(response.period_end) || null,
+    employeeName: response.employee_name || null,
+    employerName: response.employer_name || null,
     source: 'openai',
   };
 }
@@ -396,6 +400,8 @@ async function analysePayslip(text) {
     payDate: merged.payDate || null,
     periodStart: merged.periodStart || null,
     periodEnd: merged.periodEnd || null,
+    employeeName: merged.employeeName || null,
+    employerName: merged.employerName || null,
   };
   return breakdown;
 }

--- a/backend/src/services/documents/parsers/statement.js
+++ b/backend/src/services/documents/parsers/statement.js
@@ -246,6 +246,7 @@ async function llmStatementExtraction(text) {
         bank_name: { type: ['string', 'null'] },
         account_number: { type: ['string', 'null'] },
         account_type: { type: ['string', 'null'] },
+        account_holder: { type: ['string', 'null'] },
         statement_period: {
           type: 'object',
           additionalProperties: false,
@@ -390,6 +391,7 @@ async function analyseCurrentAccountStatement(text) {
     bankName: llm?.bank_name || null,
     accountType: llm?.account_type || null,
     accountNumberMasked: maskAccountNumber(llm?.account_number),
+    accountHolder: llm?.account_holder || null,
     period: {
       start: parseDate(llm?.statement_period?.start_date) || null,
       end: parseDate(llm?.statement_period?.end_date) || null,

--- a/frontend/document-vault.html
+++ b/frontend/document-vault.html
@@ -107,6 +107,9 @@
     .doc-files-panel table{ margin-bottom:0; }
     .doc-files-panel .table thead th{ font-size:.78rem; text-transform:uppercase; letter-spacing:.03em; }
     .doc-files-panel .table td{ font-size:.85rem; }
+    .progress.progress-thin{ height:6px; }
+    .processing-indicator{ display:flex; align-items:center; gap:6px; }
+    .processing-indicator .spinner-border{ width:1rem; height:1rem; }
   </style>
 
   <script>
@@ -200,6 +203,7 @@
                   <th>Filename</th>
                   <th>Uploaded</th>
                   <th>Size</th>
+                  <th>Status</th>
                   <th>Collection</th>
                   <th class="text-end">Manage</th>
                 </tr>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -39,52 +39,14 @@
           </div>
           <div class="d-flex flex-wrap gap-2 align-items-center">
             <div class="btn-group btn-group-sm" role="group" aria-label="Range picker">
-              <button id="rng-btn-quick" class="btn btn-outline-primary active" type="button">Quick</button>
-              <button id="rng-btn-custom" class="btn btn-outline-primary" type="button">Custom</button>
+              <button class="btn btn-outline-primary" type="button" data-range-option="now">Now</button>
+              <button class="btn btn-outline-primary" type="button" data-range-option="last-month">Last month</button>
+              <button class="btn btn-outline-primary" type="button" data-range-option="last-quarter">Last quarter</button>
+              <button class="btn btn-outline-primary" type="button" data-range-option="last-year">Last year</button>
             </div>
             <div class="btn-group btn-group-sm" role="group" aria-label="Delta mode">
               <button class="btn btn-outline-primary" id="delta-absolute" type="button">£ delta</button>
               <button class="btn btn-outline-primary" id="delta-percent" type="button">% delta</button>
-            </div>
-          </div>
-        </div>
-
-        <div id="rng-quick" class="mt-3">
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="rngQuick" id="rng-current-month" value="current-month">
-            <label class="form-check-label" for="rng-current-month">This month</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="rngQuick" id="rng-last-month" value="last-month">
-            <label class="form-check-label" for="rng-last-month">Last month</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="rngQuick" id="rng-last-quarter" value="last-quarter">
-            <label class="form-check-label" for="rng-last-quarter">Last quarter</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="rngQuick" id="rng-last-year" value="last-year">
-            <label class="form-check-label" for="rng-last-year">Last tax year</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="rngQuick" id="rng-year-to-date" value="year-to-date">
-            <label class="form-check-label" for="rng-year-to-date">Year to date</label>
-          </div>
-          <button class="btn btn-sm btn-primary ms-2" id="rng-apply-quick" type="button">Apply</button>
-        </div>
-
-        <div id="rng-custom" class="mt-3" style="display:none;">
-          <div class="row g-2 align-items-end">
-            <div class="col-auto">
-              <label class="form-label mb-1" for="rng-start">Start</label>
-              <input type="date" class="form-control form-control-sm" id="rng-start">
-            </div>
-            <div class="col-auto">
-              <label class="form-label mb-1" for="rng-end">End</label>
-              <input type="date" class="form-control form-control-sm" id="rng-end">
-            </div>
-            <div class="col-auto">
-              <button class="btn btn-sm btn-primary" id="rng-apply-custom" type="button">Apply</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a `DocumentInsight` model and enrich ingestion to capture document dates, holder names, metrics, and transactions for Mongo persistence
- update the insights store to upsert per-file analytics, maintain processing states, and refresh aggregates/timelines used by dashboards
- refactor analytics range parsing and dashboard UI to support Now/Last Month/Quarter/Year presets with previous-period deltas and per-file processing indicators in the document vault

## Testing
- npm --prefix services/worker test

------
https://chatgpt.com/codex/tasks/task_e_68e48b91aa508321aa6174a6a3ded7ae