### PR TITLE
Replace login and signup with WorkOS hosted AuthKit flow

### DIFF
--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -1,97 +1,78 @@
 // frontend/js/login.js
+// Redirect all sign-in flows through the WorkOS hosted authentication experience.
 (function(){
-  const form = document.getElementById('login-form');
-  const idInput = document.getElementById('identifier');
-  const pwInput = document.getElementById('password');
-  const remember = document.getElementById('remember');
-  const btn = document.getElementById('login-btn');
-  const err = document.getElementById('login-error');
+  const params = new URLSearchParams(window.location.search || '');
+  const next = params.get('next') || './home.html';
+  const error = params.get('error');
+  const manual = params.get('manual');
+  const emailHint = (params.get('email') || '').trim();
+
+  const statusEl = document.getElementById('login-status');
+  const errorEl = document.getElementById('login-error');
+  const rememberToggle = document.getElementById('rememberDevice');
+
+  const generalBtn = document.getElementById('workosLoginBtn');
   const googleBtn = document.getElementById('googleBtn');
   const microsoftBtn = document.getElementById('microsoftBtn');
   const appleBtn = document.getElementById('appleBtn');
-  const passkeyBtn = document.getElementById('passkeyBtn');
-  const params = new URLSearchParams(location.search);
-  const next = params.get('next') || './home.html';
-  const initialError = params.get('error');
 
-  const setLoading = (v)=>{ if(!btn) return; btn.disabled=v; btn.dataset.originalText = btn.dataset.originalText||btn.textContent; btn.textContent = v?'Signing in…':btn.dataset.originalText; };
-  const showError = (m)=>{ if(!err){ alert(m); return; } err.textContent=m; err.classList.remove('d-none'); };
-  const clearError = ()=>{ if(err){ err.textContent=''; err.classList.add('d-none'); } };
+  let redirected = false;
 
-  if (initialError) {
-    showError(initialError);
-  }
-
-  async function startProvider(provider, button, options = {}) {
-    if (!button) return;
-    clearError();
-    const original = button.innerHTML;
-    button.disabled = true;
-    button.innerHTML = '<span>Redirecting…</span>';
-    try {
-      const url = new URL('/api/auth/workos/authorize', location.origin);
-      if (provider) url.searchParams.set('provider', provider);
-      url.searchParams.set('next', next);
-      const rememberValue = typeof options.rememberOverride === 'boolean'
-        ? options.rememberOverride
-        : !!remember?.checked;
-      if (rememberValue) url.searchParams.set('remember', 'true');
-      if (options.intent) url.searchParams.set('intent', options.intent);
-      const emailValue = typeof options.email === 'string' ? options.email.trim() : '';
-      if (emailValue) url.searchParams.set('email', emailValue);
-      if (options.connectionId) url.searchParams.set('connection', options.connectionId);
-      const res = await fetch(url.toString(), { credentials: 'include' });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || !data.authorizationUrl) {
-        const msg = data?.error || 'Unable to start single sign-on. Please try again.';
-        showError(msg);
-        return;
-      }
-      location.href = data.authorizationUrl;
-    } catch (err) {
-      console.error('Provider start failed:', err);
-      showError('Network error. Please try again.');
-    } finally {
-      button.disabled = false;
-      if (original !== undefined) button.innerHTML = original;
+  function showError(message) {
+    if (!message) return;
+    if (errorEl) {
+      errorEl.textContent = message;
+      errorEl.classList.remove('d-none');
+    } else {
+      alert(message);
+    }
+    if (statusEl) {
+      statusEl.textContent = 'Choose how you’d like to sign in to try again.';
     }
   }
 
-  googleBtn?.addEventListener('click', () => startProvider('google', googleBtn));
-  microsoftBtn?.addEventListener('click', () => startProvider('microsoft', microsoftBtn));
-  appleBtn?.addEventListener('click', () => startProvider('apple', appleBtn));
-  passkeyBtn?.addEventListener('click', () => {
-    const emailValue = (idInput?.value || '').trim();
-    startProvider(null, passkeyBtn, {
-      intent: 'login',
-      rememberOverride: remember?.checked === true,
-      email: emailValue,
-    });
-  });
+  function buildUrl(options = {}) {
+    const url = new URL('/api/auth/workos/login', window.location.origin);
+    url.searchParams.set('next', options.next || next);
+    url.searchParams.set('intent', options.intent || 'login');
+    if (rememberToggle?.checked) {
+      url.searchParams.set('remember', 'true');
+    }
+    const loginHint = (options.email || emailHint || '').trim();
+    if (loginHint) {
+      url.searchParams.set('email', loginHint);
+    }
+    if (options.provider) {
+      url.searchParams.set('provider', options.provider);
+    }
+    return url;
+  }
 
-  form?.addEventListener('submit', async (e)=>{
-    e.preventDefault();
-    const identifier = (idInput?.value||'').trim();
-    const password = pwInput?.value || '';
-    if(!identifier || !password) return showError('Please enter your email and password.');
-    if(!/^\S+@\S+\.\S+$/.test(identifier)) return showError('Please enter a valid email address.');
-    const body = { identifier, password };
-    setLoading(true); clearError();
-    try {
-      const res = await fetch('/api/auth/login', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
-      if (res.status === 400) { let msg='Invalid credentials. Please check your details.'; try{ const j=await res.json(); if(j?.error) msg=j.error; }catch{} return showError(msg); }
-      if (res.status === 401) return showError('Unauthorized. Please sign in again.');
-      if (res.status === 429) return showError('Too many attempts. Try again later.');
-      if (res.status >= 500) return showError('Server error. Please try again shortly.');
-      if (!res.ok) return showError(`Login failed (status ${res.status}).`);
-      const data = await res.json();
-      const token = data.token; if(!token) return showError('No token returned from server.');
-      const store = (remember && remember.checked) ? localStorage : sessionStorage;
-      store.setItem('token', token);
-      if (data.user) try { store.setItem('me', JSON.stringify(data.user)); } catch {}
-      location.href = next;
-    } catch (e) {
-      console.error(e); showError('Network error. Is the server running?');
-    } finally { setLoading(false); }
-  });
+  function startHostedLogin(options = {}) {
+    if (redirected) return;
+    redirected = true;
+    if (statusEl) {
+      statusEl.textContent = 'Redirecting you to secure sign-in…';
+    }
+    const url = buildUrl(options);
+    window.location.assign(url.toString());
+  }
+
+  generalBtn?.addEventListener('click', () => startHostedLogin({}));
+  googleBtn?.addEventListener('click', () => startHostedLogin({ provider: 'google' }));
+  microsoftBtn?.addEventListener('click', () => startHostedLogin({ provider: 'microsoft' }));
+  appleBtn?.addEventListener('click', () => startHostedLogin({ provider: 'apple' }));
+
+  if (error) {
+    showError(error);
+  } else if (statusEl) {
+    statusEl.textContent = 'Redirecting you to the WorkOS hosted login…';
+  }
+
+  const autoStart = manual !== '1' && !error;
+  if (autoStart) {
+    window.setTimeout(() => startHostedLogin({}), 900);
+  } else if (statusEl && !error) {
+    statusEl.textContent = 'Choose how you’d like to sign in.';
+  }
 })();

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -70,6 +70,7 @@
     .oauth-icon.google{ border-radius:50%; background: conic-gradient(#4285f4 0 90deg,#34a853 90deg 180deg,#fbbc05 180deg 270deg,#ea4335 270deg 360deg); color:#fff }
     .oauth-icon.microsoft{ background: conic-gradient(#f25022 0 25%, #7fba00 25% 50%, #00a4ef 50% 75%, #ffb900 75% 100%); color:transparent }
     .oauth-icon.apple{ background:#000; color:#fff; border-radius:6px }
+    .oauth-icon.email{ background: var(--brand); color:#fff; border-radius:50% }
     .btn-oauth.btn-outline .oauth-icon{ background: var(--bg-surface-2); color:var(--brand); border-radius:50% }
 
     .divider{ display:flex; align-items:center; gap:.75rem; margin: .75rem 0 }
@@ -147,66 +148,48 @@
         <!-- Card side -->
         <section class="reveal">
           <div class="auth-card">
-            <h2 class="h5 mb-2 text-center">Sign in</h2>
+            <h2 class="h5 mb-2 text-center">Sign in securely</h2>
 
-            <!-- Social sign-in -->
+            <p id="login-status" class="small text-secondary text-center mb-3">
+              We’ll redirect you to the WorkOS hosted login to finish signing in.
+            </p>
+
+            <div id="login-error" class="alert alert-danger d-none small" role="alert"></div>
+
             <div class="d-grid gap-2 mb-3">
+              <button class="btn btn-oauth btn-primary" type="button" id="workosLoginBtn">
+                <span class="oauth-icon email" aria-hidden="true"><i class="bi bi-envelope-at"></i></span>
+                <span>Continue with email, passkey, or magic link</span>
+              </button>
               <button class="btn btn-oauth btn-google" type="button" id="googleBtn">
                 <span class="oauth-icon google" aria-hidden="true"></span>
-                <span>Sign in with Google</span>
+                <span>Continue with Google</span>
               </button>
               <button class="btn btn-oauth btn-microsoft" type="button" id="microsoftBtn">
                 <span class="oauth-icon microsoft" aria-hidden="true"></span>
-                <span>Sign in with Microsoft</span>
+                <span>Continue with Microsoft</span>
               </button>
               <button class="btn btn-oauth btn-apple" type="button" id="appleBtn">
                 <span class="oauth-icon apple" aria-hidden="true"><i class="bi bi-apple"></i></span>
-                <span>Sign in with Apple</span>
-              </button>
-              <button class="btn btn-oauth btn-outline" type="button" id="passkeyBtn">
-                <span class="oauth-icon" aria-hidden="true"><i class="bi bi-fingerprint"></i></span>
-                <span>Use a passkey or magic link</span>
+                <span>Continue with Apple</span>
               </button>
             </div>
 
-            <div class="divider small text-muted text-center"><span>or</span></div>
+            <div class="form-check form-switch text-start mb-3">
+              <input id="rememberDevice" class="form-check-input" type="checkbox" checked>
+              <label class="form-check-label small" for="rememberDevice">Keep me signed in on this device</label>
+            </div>
 
-            <!-- Login form (ALL IDs preserved) -->
-            <form id="login-form" novalidate>
-              <div class="form-floating mb-2">
-                <input id="identifier" class="form-control" type="email" placeholder="name@domain.com" autocomplete="username" required>
-                <label for="identifier">Email</label>
-                <div class="invalid-feedback">Enter a valid email address.</div>
-              </div>
+            <p class="small text-center text-secondary mb-3">
+              By continuing you agree to our <a href="/legal.html#terms">Terms</a> and <a href="/legal.html#privacy">Privacy Policy</a>.
+            </p>
 
-              <div class="form-floating mb-2 position-relative">
-                <input id="password" class="form-control" type="password" placeholder="••••••••" autocomplete="current-password" minlength="6" required>
-                <label for="password">Password</label>
-                <button type="button" class="btn btn-sm btn-outline position-absolute end-0 top-50 translate-middle-y me-2" id="togglePw" aria-label="Show password">
-                  <i class="bi bi-eye"></i>
-                </button>
-                <div class="invalid-feedback">Password is required.</div>
-              </div>
+            <div class="text-center small text-secondary">
+              Trouble signing in?
+              <a href="https://versatile-refuge-31.authkit.app/reset-password" target="_blank" rel="noopener">Reset your password</a>.
+            </div>
 
-              <div class="d-flex justify-content-between align-items-center mb-2">
-                <div class="form-check">
-                  <input id="remember" class="form-check-input" type="checkbox">
-                  <label class="form-check-label" for="remember">Remember me</label>
-                </div>
-                <a class="small" href="/forgot.html">Forgot password?</a>
-              </div>
-
-              <div id="login-error" class="alert alert-danger d-none small" role="alert"></div>
-
-              <button id="login-btn" class="btn btn-primary w-100" type="submit">Sign in</button>
-
-              <p class="small text-center mt-2 text-secondary">
-                By continuing you agree to our
-                <a href="/legal.html#terms">Terms</a> and <a href="/legal.html#privacy">Privacy Policy</a>.
-              </p>
-            </form>
-
-            <div class="text-center mt-2">
+            <div class="text-center mt-3">
               <span class="text-secondary small">New here?</span>
               <a class="small ms-1" href="/signup.html">Create an account</a>
             </div>
@@ -244,16 +227,6 @@
 
     // Year in footer
     document.getElementById('y').textContent = new Date().getFullYear();
-
-    // Show/hide password (aesthetic convenience)
-    const pw = document.getElementById('password');
-    const toggle = document.getElementById('togglePw');
-    toggle?.addEventListener('click', () => {
-      const show = pw.type === 'password';
-      pw.type = show ? 'text' : 'password';
-      toggle.innerHTML = show ? '<i class="bi bi-eye-slash"></i>' : '<i class="bi bi-eye"></i>';
-      toggle.setAttribute('aria-label', show ? 'Hide password' : 'Show password');
-    });
 
   </script>
 </body>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -75,6 +75,7 @@
     .oauth-icon.google{ border-radius:50%; background: conic-gradient(#4285f4 0 90deg,#34a853 90deg 180deg,#fbbc05 180deg 270deg,#ea4335 270deg 360deg) }
     .oauth-icon.microsoft{ background: conic-gradient(#f25022 0 25%, #7fba00 25% 50%, #00a4ef 50% 75%, #ffb900 75% 100%); color:transparent }
     .oauth-icon.apple{ background:#000; color:#fff; border-radius:6px }
+    .oauth-icon.email{ background: var(--brand); color:#fff; border-radius:50% }
     .btn-oauth.btn-outline .oauth-icon{ background: var(--bg-surface-2); color:var(--brand); border-radius:50% }
 
     .divider{ display:flex; align-items:center; gap:.75rem; margin: .75rem 0 }
@@ -152,7 +153,17 @@
           <div class="auth-card">
             <h2 class="h5 mb-2 text-center">Create your account</h2>
 
+            <p id="signup-status" class="small text-secondary text-center mb-3">
+              We’ll redirect you to the WorkOS hosted sign-up to finish creating your account securely.
+            </p>
+
+            <div id="signup-error" class="alert alert-danger d-none small"></div>
+
             <div class="d-grid gap-2 mb-3">
+              <button class="btn btn-oauth btn-primary" type="button" id="signupWorkOSBtn">
+                <span class="oauth-icon email" aria-hidden="true"><i class="bi bi-magic"></i></span>
+                <span>Continue with email, passkey, or magic link</span>
+              </button>
               <button class="btn btn-oauth btn-google" type="button" id="signupGoogle">
                 <span class="oauth-icon google" aria-hidden="true"></span>
                 <span>Continue with Google</span>
@@ -165,71 +176,24 @@
                 <span class="oauth-icon apple" aria-hidden="true"><i class="bi bi-apple"></i></span>
                 <span>Continue with Apple</span>
               </button>
-              <button class="btn btn-oauth btn-outline" type="button" id="signupPasskey">
-                <span class="oauth-icon" aria-hidden="true"><i class="bi bi-fingerprint"></i></span>
-                <span>Use a passkey or magic link</span>
-              </button>
             </div>
 
-            <div class="divider small text-muted text-center"><span>or</span></div>
+            <p class="small text-secondary text-center mb-0">
+              After signing up, we’ll bring you back here to complete onboarding details.
+            </p>
 
-            <form id="signupForm" novalidate>
-              <div class="row g-2 mb-2">
-                <div class="col-sm-6">
-                  <label class="form-label" for="firstName">First name</label>
-                  <input id="firstName" name="firstName" class="form-control" autocomplete="given-name" required>
-                  <div class="form-text error text-danger small" data-error-for="firstName"></div>
-                </div>
-                <div class="col-sm-6">
-                  <label class="form-label" for="lastName">Last name</label>
-                  <input id="lastName" name="lastName" class="form-control" autocomplete="family-name" required>
-                  <div class="form-text error text-danger small" data-error-for="lastName"></div>
-                </div>
-              </div>
+            <p class="small text-center text-secondary mt-3 mb-0">
+              By continuing you agree to our <a href="/legal.html#terms">Terms</a> and <a href="/legal.html#privacy">Privacy Policy</a>.
+            </p>
 
-              <div class="mb-2">
-                <label class="form-label" for="email">Email</label>
-                <input id="email" name="email" type="email" class="form-control" autocomplete="email" required>
-                <div class="form-text error text-danger small" data-error-for="email"></div>
-              </div>
-
-              <div class="mb-2">
-                <label class="form-label" for="dateOfBirth">Date of birth</label>
-                <input id="dateOfBirth" name="dateOfBirth" class="form-control" type="date" required>
-                <div class="form-text error text-danger small" data-error-for="dateOfBirth"></div>
-              </div>
-
-              <div class="row g-2 mb-2">
-                <div class="col-sm-6">
-                  <label class="form-label" for="password">Password</label>
-                  <input id="password" name="password" type="password" class="form-control" autocomplete="new-password" minlength="8" required>
-                  <div class="form-text">At least 8 characters.</div>
-                  <div class="form-text error text-danger small" data-error-for="password"></div>
-                </div>
-                <div class="col-sm-6">
-                  <label class="form-label" for="passwordConfirm">Confirm password</label>
-                  <input id="passwordConfirm" name="passwordConfirm" type="password" class="form-control" autocomplete="new-password" required>
-                  <div class="form-text error text-danger small" data-error-for="passwordConfirm"></div>
-                </div>
-              </div>
-
-              <div class="form-check mb-2">
-                <input id="agreeLegal" class="form-check-input" type="checkbox" required>
-                <label class="form-check-label" for="agreeLegal">
-                  I agree to the <a href="/legal.html#terms">Terms of Service</a> and <a href="/legal.html#privacy">Privacy Policy</a>.
-                </label>
-                <div class="form-text error text-danger small" data-error-for="agreeLegal"></div>
-              </div>
-
-              <div id="signup-error" class="alert alert-danger d-none small"></div>
-
-              <button id="signupBtn" class="btn btn-primary w-100" type="submit">Create account</button>
-              <p class="small text-muted mt-2">30-day trial included. Cancel anytime.</p>
-            </form>
-
-            <div class="text-center mt-2">
+            <div class="text-center mt-3">
               <span class="text-secondary small">Already have an account?</span>
               <a class="small ms-1" href="/login.html">Sign in</a>
+            </div>
+
+            <div class="text-center small text-secondary mt-2">
+              Invited by our team?
+              <a href="https://versatile-refuge-31.authkit.app/invite" target="_blank" rel="noopener">Open your invite link</a>.
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- replace the login experience with buttons that redirect through the WorkOS hosted AuthKit flow and keep device persistence controls
- streamline the signup page to launch the hosted sign-up, including provider-specific shortcuts and invite/reset guidance
- rewrite the login and signup scripts to auto-redirect through backend WorkOS endpoints so tokens return to the API on callback

## Testing
- not run (static front-end changes)


------
https://chatgpt.com/codex/tasks/task_e_68e51d9e8e848321bc44395a398a05fa