### PR TITLE
Simplify login/signup to WorkOS redirects

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -61,7 +61,7 @@
 
       <div class="actions">
         <a class="btn btn-primary btn-lg" href="/"><i class="bi bi-house-door me-1"></i>Home</a>
-        <a class="btn btn-outline btn-lg" href="/login.html"><i class="bi bi-box-arrow-in-right me-1"></i>Login</a>
+        <a class="btn btn-outline btn-lg" href="/api/auth/workos/login"><i class="bi bi-box-arrow-in-right me-1"></i>Login</a>
         <a class="btn btn-ghost btn-lg" href="/home.html"><i class="bi bi-speedometer2 me-1"></i>Dashboard</a>
       </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -179,7 +179,7 @@
         <a class="btn btn-outline" href="#advisor">AI Advisor</a>
         <a class="btn btn-outline" href="#security">Security</a>
         <a class="btn btn-outline" href="#faq">FAQ</a>
-        <a class="btn btn-primary" href="/login.html" id="loginBtn"><i class="bi bi-box-arrow-in-right me-1"></i> Login</a>
+        <a class="btn btn-primary" href="/api/auth/workos/login" id="loginBtn"><i class="bi bi-box-arrow-in-right me-1"></i> Login</a>
       </div>
     </div>
   </nav>
@@ -216,12 +216,12 @@
         <span class="landing-menu__tile-title">FAQ</span>
         <span class="landing-menu__tile-copy">Get answers to the top questions about pricing, coverage, and onboarding.</span>
       </a>
-      <a class="landing-menu__tile landing-menu__tile--accent" href="/login.html" id="landingMenuLogin" data-close-menu>
+      <a class="landing-menu__tile landing-menu__tile--accent" href="/api/auth/workos/login" id="landingMenuLogin" data-close-menu>
         <span class="landing-menu__tile-icon"><i class="bi bi-box-arrow-in-right"></i></span>
         <span class="landing-menu__tile-title">Login</span>
         <span class="landing-menu__tile-copy">Existing customer? Continue to your secure workspace.</span>
       </a>
-      <a class="landing-menu__tile" href="/signup.html" data-close-menu>
+      <a class="landing-menu__tile" href="/api/auth/workos/start?intent=signup" data-close-menu>
         <span class="landing-menu__tile-icon"><i class="bi bi-person-plus"></i></span>
         <span class="landing-menu__tile-title">Create account</span>
         <span class="landing-menu__tile-copy">New to AI Accountant? Start with a guided setup tailored to your needs.</span>
@@ -246,7 +246,7 @@
         Real-time dashboards, scenario planning, and HMRC integrations — all in one, secure place.
       </p>
       <div class="hero-cta">
-        <a class="btn btn-primary btn-lg" href="/login.html">Get started — Login</a>
+        <a class="btn btn-primary btn-lg" href="/api/auth/workos/login">Get started — Login</a>
         <a class="btn btn-outline btn-lg" href="#features">Explore features</a>
       </div>
       <div class="d-flex gap-2 justify-content-center mt-3">
@@ -462,7 +462,7 @@
                 </div>
               </div>
             </div>
-            <a class="btn btn-primary btn-lg mt-3" href="/login.html">Try the Advisor</a>
+            <a class="btn btn-primary btn-lg mt-3" href="/api/auth/workos/login">Try the Advisor</a>
           </div>
         </div>
       </div>
@@ -668,7 +668,7 @@
     </div>
 
     <div class="text-center mt-4">
-      <a class="btn btn-primary btn-lg" href="/login.html">Get started — it’s free to try</a>
+      <a class="btn btn-primary btn-lg" href="/api/auth/workos/login">Get started — it’s free to try</a>
     </div>
   </div>
 </section>
@@ -680,7 +680,7 @@
       <div class="card p-4 p-md-5 text-center">
         <h2 class="mb-2">Ready to take control?</h2>
         <p class="sub mx-auto">Log in to your AI Accountant and see your financial posture in a whole new light.</p>
-        <a class="btn btn-primary btn-lg mt-2" href="/login.html">Login</a>
+        <a class="btn btn-primary btn-lg mt-2" href="/api/auth/workos/login">Login</a>
       </div>
     </div>
   </section>
@@ -690,8 +690,8 @@
     <div class="container d-flex flex-wrap gap-3 align-items-center justify-content-between">
       <div class="small">&copy; <span id="y"></span> AI Accountant. All rights reserved.</div>
       <div class="d-flex gap-3 small">
-        <a class="link-secondary" href="/login.html">Login</a>
-        <a class="link-secondary" href="/signup.html">Sign up</a>
+        <a class="link-secondary" href="/api/auth/workos/login">Login</a>
+        <a class="link-secondary" href="/api/auth/workos/start?intent=signup">Sign up</a>
         <a class="link-secondary" href="/home.html">Dashboard</a>
       </div>
     </div>

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -93,6 +93,17 @@
     }
   }
 
+  function buildWorkOSUrl({ intent = 'login', next, email, remember = true } = {}) {
+    const normalizedIntent = intent === 'signup' ? 'signup' : 'login';
+    const basePath = normalizedIntent === 'signup' ? '/api/auth/workos/start' : '/api/auth/workos/login';
+    const url = new URL(basePath, window.location.origin);
+    if (next) url.searchParams.set('next', next);
+    url.searchParams.set('intent', normalizedIntent);
+    if (remember) url.searchParams.set('remember', 'true');
+    if (email) url.searchParams.set('email', email);
+    return url.toString();
+  }
+
   async function requireAuth() {
     const t = getToken();
     if (!t || isExpired(t)) {
@@ -134,8 +145,11 @@
 
     // Helper: redirect to login with ?next=<current>
     function toLogin() {
-      const next = encodeURIComponent(location.pathname + location.search);
-      location.replace(`./login.html?next=${next}`);
+      const url = buildWorkOSUrl({
+        intent: 'login',
+        next: location.pathname + location.search,
+      });
+      location.replace(url);
     }
     // Helper: redirect to app home or provided next
     function toAppHomeFromLogin() {
@@ -197,9 +211,13 @@
     if (g && name) g.textContent = name;
   }
 
-  function signOut() {
+  function signOut({ next } = {}) {
     clearTokens();
-    location.href = './login.html';
+    const url = buildWorkOSUrl({
+      intent: 'login',
+      next: next || (location.pathname + location.search) || '/index.html',
+    });
+    window.location.assign(url);
   }
 
   async function getCurrentUser({ force = false } = {}) {
@@ -215,6 +233,7 @@
     enforce,
     setBannerTitle,
     signOut,
+    buildWorkOSUrl,
     getCurrentUser,
     get me() { return window.__ME__; }
   };

--- a/frontend/js/billing.js
+++ b/frontend/js/billing.js
@@ -30,8 +30,11 @@ const money  = (sym, n) => `${sym}${Number(n||0).toFixed(2)}`;
 const plansContainer = () => $id('plans-row') || $id('plans-grid') || $id('billing-plans');
 
 function hardRedirectToLogin() {
-  const next = encodeURIComponent(location.pathname + location.search);
-  location.href = `./login.html?next=${next}`;
+  const nextPath = location.pathname + location.search;
+  const url = (window.Auth && typeof Auth.buildWorkOSUrl === 'function')
+    ? Auth.buildWorkOSUrl({ intent: 'login', next: nextPath })
+    : `/api/auth/workos/login?next=${encodeURIComponent(nextPath)}`;
+  location.href = url;
 }
 
 /* -------------------------- cycle toggle -------------------------- */

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -1,78 +1,54 @@
 // frontend/js/login.js
-// Redirect all sign-in flows through the WorkOS hosted authentication experience.
+// Minimal redirect shim: immediately send users to the WorkOS hosted login.
 (function(){
   const params = new URLSearchParams(window.location.search || '');
-  const next = params.get('next') || './home.html';
-  const error = params.get('error');
-  const manual = params.get('manual');
-  const emailHint = (params.get('email') || '').trim();
+  const manual = params.get('manual') === '1';
+  const errorMessage = params.get('error');
+  const next = params.get('next') || undefined;
+  const email = (params.get('email') || '').trim() || undefined;
+  const rememberParam = (params.get('remember') || '').toLowerCase();
+  const remember = rememberParam ? ['true','1','yes','on'].includes(rememberParam) : true;
 
-  const statusEl = document.getElementById('login-status');
-  const errorEl = document.getElementById('login-error');
-  const rememberToggle = document.getElementById('rememberDevice');
+  const statusEl = document.getElementById('redirect-status');
+  const errorEl = document.getElementById('redirect-error');
+  const linkEl = document.getElementById('redirect-link');
 
-  const generalBtn = document.getElementById('workosLoginBtn');
-  const googleBtn = document.getElementById('googleBtn');
-  const microsoftBtn = document.getElementById('microsoftBtn');
-  const appleBtn = document.getElementById('appleBtn');
-
-  let redirected = false;
+  function buildUrl() {
+    if (window.Auth && typeof Auth.buildWorkOSUrl === 'function') {
+      return Auth.buildWorkOSUrl({ intent: 'login', next, email, remember });
+    }
+    const url = new URL('/api/auth/workos/login', window.location.origin);
+    url.searchParams.set('intent', 'login');
+    if (next) url.searchParams.set('next', next);
+    if (remember) url.searchParams.set('remember', 'true');
+    if (email) url.searchParams.set('email', email);
+    return url.toString();
+  }
 
   function showError(message) {
-    if (!message) return;
     if (errorEl) {
       errorEl.textContent = message;
       errorEl.classList.remove('d-none');
     } else {
-      alert(message);
+      console.error('Login redirect error:', message);
     }
     if (statusEl) {
-      statusEl.textContent = 'Choose how you’d like to sign in to try again.';
+      statusEl.textContent = 'Select “Continue” below to open the secure login.';
     }
   }
 
-  function buildUrl(options = {}) {
-    const url = new URL('/api/auth/workos/login', window.location.origin);
-    url.searchParams.set('next', options.next || next);
-    url.searchParams.set('intent', options.intent || 'login');
-    if (rememberToggle?.checked) {
-      url.searchParams.set('remember', 'true');
-    }
-    const loginHint = (options.email || emailHint || '').trim();
-    if (loginHint) {
-      url.searchParams.set('email', loginHint);
-    }
-    if (options.provider) {
-      url.searchParams.set('provider', options.provider);
-    }
-    return url;
-  }
+  const destination = buildUrl();
+  if (linkEl) linkEl.href = destination;
 
-  function startHostedLogin(options = {}) {
-    if (redirected) return;
-    redirected = true;
-    if (statusEl) {
-      statusEl.textContent = 'Redirecting you to secure sign-in…';
-    }
-    const url = buildUrl(options);
-    window.location.assign(url.toString());
-  }
-
-  generalBtn?.addEventListener('click', () => startHostedLogin({}));
-  googleBtn?.addEventListener('click', () => startHostedLogin({ provider: 'google' }));
-  microsoftBtn?.addEventListener('click', () => startHostedLogin({ provider: 'microsoft' }));
-  appleBtn?.addEventListener('click', () => startHostedLogin({ provider: 'apple' }));
-
-  if (error) {
-    showError(error);
+  if (errorMessage) {
+    showError(errorMessage);
   } else if (statusEl) {
-    statusEl.textContent = 'Redirecting you to the WorkOS hosted login…';
+    statusEl.textContent = 'Redirecting you to the secure WorkOS login…';
   }
 
-  const autoStart = manual !== '1' && !error;
-  if (autoStart) {
-    window.setTimeout(() => startHostedLogin({}), 900);
-  } else if (statusEl && !error) {
-    statusEl.textContent = 'Choose how you’d like to sign in.';
+  if (!manual && !errorMessage) {
+    window.setTimeout(() => {
+      window.location.assign(destination);
+    }, 150);
   }
 })();

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -84,11 +84,17 @@ document.addEventListener('click', (ev) => {
     } else {
       // Hard fallback: clear tokens + go to login
       ['token','jwt','authToken','me'].forEach(k => { try { localStorage.removeItem(k); sessionStorage.removeItem(k); } catch {} });
-      const next = encodeURIComponent(location.pathname + location.search);
-      location.href = `./login.html?next=${next}`;
+      const nextPath = location.pathname + location.search;
+      const url = (window.Auth && typeof Auth.buildWorkOSUrl === 'function')
+        ? Auth.buildWorkOSUrl({ intent: 'login', next: nextPath })
+        : `/api/auth/workos/login?next=${encodeURIComponent(nextPath)}`;
+      location.href = url;
     }
   } catch {
-    location.href = './login.html';
+    const url = (window.Auth && typeof Auth.buildWorkOSUrl === 'function')
+      ? Auth.buildWorkOSUrl({ intent: 'login' })
+      : '/api/auth/workos/login';
+    location.href = url;
   }
 });
 

--- a/frontend/js/signup.js
+++ b/frontend/js/signup.js
@@ -1,75 +1,52 @@
 // frontend/js/signup.js
-// Routes sign-up flows through the WorkOS hosted experience so the backend receives the callback.
+// Minimal redirect shim: send users straight to the WorkOS hosted sign-up.
 (function(){
   const params = new URLSearchParams(window.location.search || '');
-  const next = params.get('next') || './home.html';
-  const error = params.get('error');
-  const manual = params.get('manual');
-  const emailHint = (params.get('email') || '').trim();
+  const manual = params.get('manual') === '1';
+  const errorMessage = params.get('error');
+  const next = params.get('next') || undefined;
+  const email = (params.get('email') || '').trim() || undefined;
 
-  const statusEl = document.getElementById('signup-status');
-  const errorEl = document.getElementById('signup-error');
+  const statusEl = document.getElementById('redirect-status');
+  const errorEl = document.getElementById('redirect-error');
+  const linkEl = document.getElementById('redirect-link');
 
-  const primaryBtn = document.getElementById('signupWorkOSBtn');
-  const googleBtn = document.getElementById('signupGoogle');
-  const microsoftBtn = document.getElementById('signupMicrosoft');
-  const appleBtn = document.getElementById('signupApple');
-
-  let redirected = false;
+  function buildUrl() {
+    if (window.Auth && typeof Auth.buildWorkOSUrl === 'function') {
+      return Auth.buildWorkOSUrl({ intent: 'signup', next, email, remember: true });
+    }
+    const url = new URL('/api/auth/workos/start', window.location.origin);
+    url.searchParams.set('intent', 'signup');
+    url.searchParams.set('remember', 'true');
+    if (next) url.searchParams.set('next', next);
+    if (email) url.searchParams.set('email', email);
+    return url.toString();
+  }
 
   function showError(message) {
-    if (!message) return;
     if (errorEl) {
       errorEl.textContent = message;
       errorEl.classList.remove('d-none');
     } else {
-      alert(message);
+      console.error('Signup redirect error:', message);
     }
     if (statusEl) {
-      statusEl.textContent = 'Choose how you’d like to continue your sign-up.';
+      statusEl.textContent = 'Select “Continue” below to create your account.';
     }
   }
 
-  function buildUrl(options = {}) {
-    const url = new URL('/api/auth/workos/start', window.location.origin);
-    url.searchParams.set('next', options.next || next);
-    url.searchParams.set('intent', options.intent || 'signup');
-    url.searchParams.set('remember', 'true');
-    const loginHint = (options.email || emailHint || '').trim();
-    if (loginHint) {
-      url.searchParams.set('email', loginHint);
-    }
-    if (options.provider) {
-      url.searchParams.set('provider', options.provider);
-    }
-    return url;
-  }
+  const destination = buildUrl();
+  if (linkEl) linkEl.href = destination;
 
-  function startHostedSignup(options = {}) {
-    if (redirected) return;
-    redirected = true;
-    if (statusEl) {
-      statusEl.textContent = 'Redirecting you to secure sign-up…';
-    }
-    const url = buildUrl(options);
-    window.location.assign(url.toString());
-  }
-
-  primaryBtn?.addEventListener('click', () => startHostedSignup({}));
-  googleBtn?.addEventListener('click', () => startHostedSignup({ provider: 'google' }));
-  microsoftBtn?.addEventListener('click', () => startHostedSignup({ provider: 'microsoft' }));
-  appleBtn?.addEventListener('click', () => startHostedSignup({ provider: 'apple' }));
-
-  if (error) {
-    showError(error);
+  if (errorMessage) {
+    showError(errorMessage);
   } else if (statusEl) {
-    statusEl.textContent = 'Redirecting you to the WorkOS hosted sign-up…';
+    statusEl.textContent = 'Redirecting you to the secure WorkOS sign-up…';
   }
 
-  const autoStart = manual !== '1' && !error;
-  if (autoStart) {
-    window.setTimeout(() => startHostedSignup({}), 900);
-  } else if (statusEl && !error) {
-    statusEl.textContent = 'Choose how you’d like to continue your sign-up.';
+  if (!manual && !errorMessage) {
+    window.setTimeout(() => {
+      window.location.assign(destination);
+    }, 150);
   }
 })();

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -4,231 +4,34 @@
   <meta charset="utf-8">
   <title>Login — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-
-  <!-- Theme + libs (unchanged) -->
   <script>window.__API_BASE = window.__API_BASE || 'http://localhost:3000';</script>
   <script src="/js/head-include.js"></script>
-
   <style>
-    :root{
-      --auth-maxw: 980px;
-      --card-w: 440px;
-    }
-
-    body{ background: var(--bg-body); color: var(--fg) }
-
-    /* Mini top nav (aesthetic only) */
-    .landing-nav{ position:sticky; top:0; z-index:1020; backdrop-filter:saturate(1.2) blur(8px) }
-    .landing-nav .btn{ padding:.5rem .9rem }
-    .brand-mark{ display:flex; align-items:center; gap:.6rem; font-weight:700; letter-spacing:.2px; text-decoration:none; color:var(--fg) }
-    .brand-dot{ width:12px; height:12px; border-radius:50%; background: radial-gradient(circle at 30% 30%, var(--brand), var(--brand-hover)); box-shadow:0 0 24px color-mix(in oklab, var(--brand) 45%, transparent) }
-
-    /* Auth shell + layout */
-    .auth{ min-height: calc(100vh - 56px); display:grid; place-items:center; position:relative; overflow:hidden }
-    .auth-inner{ width:100%; max-width: var(--auth-maxw); padding: clamp(2rem, 4vw, 3rem) 1.25rem; position:relative; z-index:2 }
-    .auth-grid{ display:grid; grid-template-columns: 1.1fr .9fr; gap: clamp(1.25rem, 3vw, 2rem) }
-    @media (max-width: 992px){ .auth-grid{ grid-template-columns: 1fr } }
-
-    /* Copy side */
-    .copy{ padding: clamp(1rem, 2vw, 1.25rem) }
-    .eyebrow{ color:var(--fg-3); font-weight:600; text-transform:uppercase; letter-spacing:.12em }
-    h1{ font-size: clamp(1.6rem, 3.6vw, 2.2rem); line-height:1.2; margin:.5rem 0 .75rem;
-        background: linear-gradient(120deg, var(--fg), color-mix(in oklab, var(--brand) 35%, var(--fg)));
-        -webkit-background-clip:text; background-clip:text; color:transparent; }
-    .sub{ color:var(--fg-2); max-width: 60ch }
-
-    .chip{ display:inline-flex; align-items:center; gap:.5rem; border:1px solid var(--bd-hairline); padding:.35rem .6rem; border-radius:999px; background:var(--bg-surface); font-size:.9rem }
-
-    /* Card side */
-    .auth-card{
-      width:100%; max-width: var(--card-w);
-      background: var(--bg-surface);
-      border: 1px solid var(--bd-hairline);
-      border-radius: 1.25rem;
-      box-shadow: var(--shadow);
-      padding: 1.25rem;
-      margin-inline: auto;
-      transform: translateY(8px);
-      transition: transform .35s ease, box-shadow .35s ease;
-    }
-    .auth-card:hover{ transform: translateY(-2px); box-shadow: var(--shadow-2) }
-
-    .btn-outline{
-      --bs-btn-bg: transparent; --bs-btn-border-color: var(--bd-hairline); --bs-btn-color: var(--fg);
-      --bs-btn-hover-bg: var(--bg-surface-2); --bs-btn-hover-border-color: var(--bd); box-shadow:none;
-    }
-
-    /* OAuth buttons (do nothing on click for now) */
-    .btn-oauth{ display:flex; align-items:center; justify-content:center; gap:.6rem; width:100%; font-weight:600 }
-    .btn-google{ background: var(--bg-surface); border:1px solid var(--bd-hairline) }
-    .btn-google:hover{ background: var(--bg-surface-2) }
-    .btn-microsoft{ background: var(--bg-surface); border:1px solid var(--bd-hairline) }
-    .btn-microsoft:hover{ background: var(--bg-surface-2) }
-    .btn-apple{ background: #000; color:#fff; border:1px solid #000 }
-    .btn-apple:hover{ filter:brightness(1.08) }
-    .oauth-icon{ width:18px; height:18px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; font-size:.7rem; font-weight:700; color:#fff }
-    .oauth-icon.google{ border-radius:50%; background: conic-gradient(#4285f4 0 90deg,#34a853 90deg 180deg,#fbbc05 180deg 270deg,#ea4335 270deg 360deg); color:#fff }
-    .oauth-icon.microsoft{ background: conic-gradient(#f25022 0 25%, #7fba00 25% 50%, #00a4ef 50% 75%, #ffb900 75% 100%); color:transparent }
-    .oauth-icon.apple{ background:#000; color:#fff; border-radius:6px }
-    .oauth-icon.email{ background: var(--brand); color:#fff; border-radius:50% }
-    .btn-oauth.btn-outline .oauth-icon{ background: var(--bg-surface-2); color:var(--brand); border-radius:50% }
-
-    .divider{ display:flex; align-items:center; gap:.75rem; margin: .75rem 0 }
-    .divider::before, .divider::after{ content:""; height:1px; background: var(--bd-hairline); flex:1 }
-
-    /* Form polish (IDs unchanged for your login.js) */
-    .form-floating>.form-control{ background: var(--bg-surface-2); border-color: var(--bd-hairline) }
-    .form-floating>.form-control:focus{ border-color: color-mix(in oklab, var(--brand) 40%, var(--bd)); box-shadow:none }
-    .form-text a{ text-decoration: none }
-
-    /* Background flair */
-    .mesh{
-      position:absolute; inset:-10% -10% auto -10%; height: 70%;
-      background:
-        radial-gradient(1200px 600px at 15% 35%, color-mix(in oklab,var(--brand) 18%,transparent), transparent),
-        radial-gradient(1200px 600px at 80% 20%, color-mix(in oklab,var(--brand-hover) 18%,transparent), transparent),
-        radial-gradient(1200px 600px at 50% 90%, color-mix(in oklab,#7FDCCB 20%,transparent), transparent);
-      mask-image: radial-gradient(1200px 600px at 50% 40%, #000, transparent 70%);
-      opacity:.6;
-    }
-    .grid{ position:absolute; inset:0;
-      background-image:
-        linear-gradient(to right, color-mix(in oklab, var(--brand) 10%, transparent) 1px, transparent 1px),
-        linear-gradient(to bottom, color-mix(in oklab, var(--brand) 10%, transparent) 1px, transparent 1px);
-      background-size: 52px 52px; opacity:.14;
-      mask-image: linear-gradient(to bottom, #000, transparent 75%)
-    }
-
-    /* Entrance animation */
-    .reveal{ opacity:0; transform: translateY(16px); transition: opacity .6s ease, transform .6s ease }
-    .reveal.in{ opacity:1; transform:none }
-    @media (prefers-reduced-motion: reduce){ .reveal{ transition:none } }
-
-    /* Keep your existing error block spacing tidy */
-    #login-error{ min-height: 1.25rem }
+    body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:var(--bg-body);color:var(--fg);margin:0;font-family:var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);}
+    main{width:100%;padding:2rem;}
+    .redirect-card{max-width:520px;margin:0 auto;background:var(--bg-surface);border:1px solid var(--bd-hairline);border-radius:1rem;padding:2rem;box-shadow:var(--shadow,0 20px 45px -25px rgba(15,23,42,.65));text-align:center;}
+    h1{font-size:1.8rem;margin-bottom:.75rem;}
+    p{margin-bottom:1rem;}
+    #redirect-error{margin-bottom:1rem;}
+    .fallback{margin-top:1.5rem;color:var(--fg-2);font-size:.9rem;}
+    .fallback a{color:inherit;font-weight:600;}
   </style>
 </head>
 <body>
-
-  <!-- Mini top nav -->
-  <nav class="landing-nav navbar navbar-expand-lg py-2 border-bottom bg-body-tertiary">
-    <div class="container">
-      <a class="brand-mark" href="/"><span class="brand-dot"></span><span>AI Accountant</span></a>
-      <div class="ms-auto d-flex align-items-center gap-2">
-        <a class="btn btn-outline" href="/">Home</a>
-        <a class="btn btn-primary" href="/signup.html">Create account</a>
-      </div>
-    </div>
-  </nav>
-
-  <!-- Auth shell -->
-  <main class="auth">
-    <div class="mesh" aria-hidden="true"></div>
-    <div class="grid" aria-hidden="true"></div>
-
-    <div class="auth-inner">
-      <div class="auth-grid">
-
-        <!-- Copy side -->
-        <section class="copy reveal">
-          <div class="eyebrow">Welcome back</div>
-          <h1>Log in and pick up where you left off.</h1>
-          <p class="sub">
-            Your dashboard, reconciliations, and AI Advisor are ready. Secure by design with
-            read-only bank connections, encryption, and export-anytime controls.
-          </p>
-
-          <div class="d-flex flex-wrap gap-2 mt-3">
-            <span class="chip"><i class="bi bi-shield-lock"></i> Encrypted</span>
-            <span class="chip"><i class="bi bi-bank"></i> Open Banking</span>
-            <span class="chip"><i class="bi bi-check2-circle"></i> HMRC-ready</span>
-          </div>
-        </section>
-
-        <!-- Card side -->
-        <section class="reveal">
-          <div class="auth-card">
-            <h2 class="h5 mb-2 text-center">Sign in securely</h2>
-
-            <p id="login-status" class="small text-secondary text-center mb-3">
-              We’ll redirect you to the WorkOS hosted login to finish signing in.
-            </p>
-
-            <div id="login-error" class="alert alert-danger d-none small" role="alert"></div>
-
-            <div class="d-grid gap-2 mb-3">
-              <button class="btn btn-oauth btn-primary" type="button" id="workosLoginBtn">
-                <span class="oauth-icon email" aria-hidden="true"><i class="bi bi-envelope-at"></i></span>
-                <span>Continue with email, passkey, or magic link</span>
-              </button>
-              <button class="btn btn-oauth btn-google" type="button" id="googleBtn">
-                <span class="oauth-icon google" aria-hidden="true"></span>
-                <span>Continue with Google</span>
-              </button>
-              <button class="btn btn-oauth btn-microsoft" type="button" id="microsoftBtn">
-                <span class="oauth-icon microsoft" aria-hidden="true"></span>
-                <span>Continue with Microsoft</span>
-              </button>
-              <button class="btn btn-oauth btn-apple" type="button" id="appleBtn">
-                <span class="oauth-icon apple" aria-hidden="true"><i class="bi bi-apple"></i></span>
-                <span>Continue with Apple</span>
-              </button>
-            </div>
-
-            <div class="form-check form-switch text-start mb-3">
-              <input id="rememberDevice" class="form-check-input" type="checkbox" checked>
-              <label class="form-check-label small" for="rememberDevice">Keep me signed in on this device</label>
-            </div>
-
-            <p class="small text-center text-secondary mb-3">
-              By continuing you agree to our <a href="/legal.html#terms">Terms</a> and <a href="/legal.html#privacy">Privacy Policy</a>.
-            </p>
-
-            <div class="text-center small text-secondary">
-              Trouble signing in?
-              <a href="https://versatile-refuge-31.authkit.app/reset-password" target="_blank" rel="noopener">Reset your password</a>.
-            </div>
-
-            <div class="text-center mt-3">
-              <span class="text-secondary small">New here?</span>
-              <a class="small ms-1" href="/signup.html">Create an account</a>
-            </div>
-          </div>
-        </section>
-
-      </div>
+  <main>
+    <div class="redirect-card" role="status" aria-live="polite">
+      <h1>Redirecting to WorkOS</h1>
+      <p id="redirect-status" class="text-secondary">We’re sending you to the secure WorkOS login to sign in with email, passkey, or magic link.</p>
+      <div id="redirect-error" class="alert alert-danger d-none" role="alert"></div>
+      <a id="redirect-link" class="btn btn-primary w-100" href="/api/auth/workos/login">Continue to WorkOS</a>
+      <p class="fallback">Need help? <a href="https://versatile-refuge-31.authkit.app/reset-password" target="_blank" rel="noopener">Reset your password</a>.</p>
     </div>
   </main>
 
-  <!-- Footer (light, aesthetic only) -->
-  <footer class="site-footer py-4">
-    <div class="container d-flex flex-wrap gap-3 align-items-center justify-content-between">
-      <div class="small">&copy; <span id="y"></span> AI Accountant. All rights reserved.</div>
-      <div class="d-flex gap-3 small">
-        <a class="link-secondary" href="/">Home</a>
-        <a class="link-secondary" href="/signup.html">Sign up</a>
-        <a class="link-secondary" href="/legal.html">Legal</a>
-      </div>
-    </div>
-  </footer>
-
-  <!-- Scripts (core auth unchanged) -->
   <script src="./js/auth.js"></script>
-  <script>Auth.enforce({ allowAnonymous: ['login.html','signup.html','index.html'], bounceIfAuthed: true });</script>
-  <script src="./js/login.js"></script>
-
-  <!-- Tiny UI-only helpers (no backend impact) -->
   <script>
-    // Entrance reveal
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach(e => { if(e.isIntersecting){ e.target.classList.add('in'); io.unobserve(e.target); } });
-    }, { threshold: 0.14 });
-    document.querySelectorAll('.reveal').forEach(el => io.observe(el));
-
-    // Year in footer
-    document.getElementById('y').textContent = new Date().getFullYear();
-
+    Auth.enforce({ allowAnonymous: ['login.html','signup.html','index.html'], bounceIfAuthed: true });
   </script>
+  <script src="./js/login.js"></script>
 </body>
 </html>
-

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -4,234 +4,34 @@
   <meta charset="utf-8" />
   <title>Sign up — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-
-  <!-- Match login head includes -->
   <script>window.__API_BASE = window.__API_BASE || 'http://localhost:3000';</script>
   <script src="/js/head-include.js"></script>
-  <script src="/js/http-shim.js"></script>
-
   <style>
-    :root{
-      --auth-maxw: 980px;
-      --card-w: 440px;
-    }
-
-    body{ background: var(--bg-body); color: var(--fg) }
-
-    /* Mini top nav (matches login) */
-    .landing-nav{ position:sticky; top:0; z-index:1020; backdrop-filter:saturate(1.2) blur(8px) }
-    .landing-nav .btn{ padding:.5rem .9rem }
-    .brand-mark{ display:flex; align-items:center; gap:.6rem; font-weight:700; letter-spacing:.2px; text-decoration:none; color:var(--fg) }
-    .brand-dot{ width:12px; height:12px; border-radius:50%;
-      background: radial-gradient(circle at 30% 30%, var(--brand), var(--brand-hover));
-      box-shadow:0 0 24px color-mix(in oklab, var(--brand) 45%, transparent)
-    }
-
-    /* Hero/auth shell (matches login) */
-    .auth{ min-height: calc(100vh - 56px); display:grid; place-items:center; position:relative; overflow:hidden }
-    .auth-inner{ width:100%; max-width: var(--auth-maxw); padding: clamp(2rem, 4vw, 3rem) 1.25rem; position:relative; z-index:2 }
-    .auth-grid{ display:grid; grid-template-columns: 1.1fr .9fr; gap: clamp(1.25rem, 3vw, 2rem) }
-    @media (max-width: 992px){ .auth-grid{ grid-template-columns: 1fr } }
-
-    /* Copy side (matches login) */
-    .copy{ padding: clamp(1rem, 2vw, 1.25rem) }
-    .eyebrow{ color:var(--fg-3); font-weight:600; text-transform:uppercase; letter-spacing:.12em }
-    h1{ font-size: clamp(1.6rem, 3.6vw, 2.2rem); line-height:1.2; margin:.5rem 0 .75rem;
-        background: linear-gradient(120deg, var(--fg), color-mix(in oklab, var(--brand) 35%, var(--fg)));
-        -webkit-background-clip:text; background-clip:text; color:transparent; }
-    .sub{ color:var(--fg-2); max-width: 60ch }
-    .chip{ display:inline-flex; align-items:center; gap:.5rem; border:1px solid var(--bd-hairline); padding:.35rem .6rem; border-radius:999px; background:var(--bg-surface); font-size:.9rem }
-
-    /* Card side (matches login) */
-    .auth-card{
-      width:100%; max-width: var(--card-w);
-      background: var(--bg-surface);
-      border: 1px solid var(--bd-hairline);
-      border-radius: 1.25rem;
-      box-shadow: var(--shadow);
-      padding: 1.25rem;
-      margin-inline: auto;
-      transform: translateY(8px);
-      transition: transform .35s ease, box-shadow .35s ease;
-    }
-    .auth-card:hover{ transform: translateY(-2px); box-shadow: var(--shadow-2) }
-
-    .btn-oauth{ display:flex; align-items:center; justify-content:center; gap:.6rem; width:100%; font-weight:600 }
-    .btn-google{ background: var(--bg-surface); border:1px solid var(--bd-hairline) }
-    .btn-google:hover{ background: var(--bg-surface-2) }
-    .btn-microsoft{ background: var(--bg-surface); border:1px solid var(--bd-hairline) }
-    .btn-microsoft:hover{ background: var(--bg-surface-2) }
-    .btn-apple{ background:#000; color:#fff; border:1px solid #000 }
-    .btn-apple:hover{ filter:brightness(1.08) }
-    .btn-outline{
-      --bs-btn-bg: transparent;
-      --bs-btn-border-color: var(--bd-hairline);
-      --bs-btn-color: var(--fg);
-      --bs-btn-hover-bg: var(--bg-surface-2);
-      --bs-btn-hover-border-color: var(--bd);
-      box-shadow:none;
-    }
-    .oauth-icon{ width:18px; height:18px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; font-size:.7rem; font-weight:700; color:#fff }
-    .oauth-icon.google{ border-radius:50%; background: conic-gradient(#4285f4 0 90deg,#34a853 90deg 180deg,#fbbc05 180deg 270deg,#ea4335 270deg 360deg) }
-    .oauth-icon.microsoft{ background: conic-gradient(#f25022 0 25%, #7fba00 25% 50%, #00a4ef 50% 75%, #ffb900 75% 100%); color:transparent }
-    .oauth-icon.apple{ background:#000; color:#fff; border-radius:6px }
-    .oauth-icon.email{ background: var(--brand); color:#fff; border-radius:50% }
-    .btn-oauth.btn-outline .oauth-icon{ background: var(--bg-surface-2); color:var(--brand); border-radius:50% }
-
-    .divider{ display:flex; align-items:center; gap:.75rem; margin: .75rem 0 }
-    .divider::before, .divider::after{ content:""; height:1px; background: var(--bd-hairline); flex:1 }
-
-    /* Background flair (matches login) */
-    .mesh{
-      position:absolute; inset:-10% -10% auto -10%; height: 70%;
-      background:
-        radial-gradient(1200px 600px at 15% 35%, color-mix(in oklab,var(--brand) 18%,transparent), transparent),
-        radial-gradient(1200px 600px at 80% 20%, color-mix(in oklab,var(--brand-hover) 18%,transparent), transparent),
-        radial-gradient(1200px 600px at 50% 90%, color-mix(in oklab,#7FDCCB 20%,transparent), transparent);
-      mask-image: radial-gradient(1200px 600px at 50% 40%, #000, transparent 70%);
-      opacity:.6;
-    }
-    .grid{ position:absolute; inset:0;
-      background-image:
-        linear-gradient(to right, color-mix(in oklab, var(--brand) 10%, transparent) 1px, transparent 1px),
-        linear-gradient(to bottom, color-mix(in oklab, var(--brand) 10%, transparent) 1px, transparent 1px);
-      background-size: 52px 52px; opacity:.14;
-      mask-image: linear-gradient(to bottom, #000, transparent 75%)
-    }
-
-    /* Entrance animation (matches login) */
-    .reveal{ opacity:0; transform: translateY(16px); transition: opacity .6s ease, transform .6s ease }
-    .reveal.in{ opacity:1; transform:none }
-    @media (prefers-reduced-motion: reduce){ .reveal{ transition:none } }
-
-    /* Minimal on-theme 'PHLOAT' text (visual only) */
-    .phloat-lockup{
-      text-align:center; font-weight:800; letter-spacing:.18em; text-transform:uppercase; padding:.25rem 0 .5rem;
-      background: linear-gradient(120deg, var(--brand), color-mix(in oklab, var(--brand-hover) 60%, var(--fg)));
-      -webkit-background-clip: text; background-clip: text; color: transparent;
-    }
-
-    /* Keep your existing error block spacing tidy */
-    #signup-error{ min-height: 1.25rem }
+    body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:var(--bg-body);color:var(--fg);margin:0;font-family:var(--font-sans,'Inter',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif);}
+    main{width:100%;padding:2rem;}
+    .redirect-card{max-width:520px;margin:0 auto;background:var(--bg-surface);border:1px solid var(--bd-hairline);border-radius:1rem;padding:2rem;box-shadow:var(--shadow,0 20px 45px -25px rgba(15,23,42,.65));text-align:center;}
+    h1{font-size:1.8rem;margin-bottom:.75rem;}
+    p{margin-bottom:1rem;}
+    #redirect-error{margin-bottom:1rem;}
+    .fallback{margin-top:1.5rem;color:var(--fg-2);font-size:.9rem;}
+    .fallback a{color:inherit;font-weight:600;}
   </style>
 </head>
-
 <body>
-  <!-- Mini top nav -->
-  <nav class="landing-nav navbar navbar-expand-lg py-2 border-bottom bg-body-tertiary">
-    <div class="container">
-      <a class="brand-mark" href="/"><span class="brand-dot"></span><span>AI Accountant</span></a>
-      <div class="ms-auto d-flex align-items-center gap-2">
-        <a class="btn btn-outline" href="/login.html">Sign in</a>
-      </div>
-    </div>
-  </nav>
-
-  <!-- Auth hero -->
-  <main class="auth">
-    <div class="mesh" aria-hidden="true"></div>
-    <div class="grid" aria-hidden="true"></div>
-
-    <div class="auth-inner">
-      <div class="auth-grid">
-        <!-- Copy side (mirrors login) -->
-        <section class="copy reveal">
-          <div class="eyebrow">Get started</div>
-          <h1>Create your account</h1>
-          <p class="sub">
-            Join AI Accountant to manage documents, connect HMRC & banks, and get real-time insights.
-          </p>
-          <div class="d-flex flex-wrap gap-2 mt-3">
-            <span class="chip"><i class="bi bi-shield-lock"></i> Secure vault</span>
-            <span class="chip"><i class="bi bi-bank"></i> Open Banking</span>
-            <span class="chip"><i class="bi bi-check2-circle"></i> HMRC-ready</span>
-          </div>
-        </section>
-
-        <!-- Card side -->
-        <section class="reveal">
-          <div class="auth-card">
-            <h2 class="h5 mb-2 text-center">Create your account</h2>
-
-            <p id="signup-status" class="small text-secondary text-center mb-3">
-              We’ll redirect you to the WorkOS hosted sign-up to finish creating your account securely.
-            </p>
-
-            <div id="signup-error" class="alert alert-danger d-none small"></div>
-
-            <div class="d-grid gap-2 mb-3">
-              <button class="btn btn-oauth btn-primary" type="button" id="signupWorkOSBtn">
-                <span class="oauth-icon email" aria-hidden="true"><i class="bi bi-magic"></i></span>
-                <span>Continue with email, passkey, or magic link</span>
-              </button>
-              <button class="btn btn-oauth btn-google" type="button" id="signupGoogle">
-                <span class="oauth-icon google" aria-hidden="true"></span>
-                <span>Continue with Google</span>
-              </button>
-              <button class="btn btn-oauth btn-microsoft" type="button" id="signupMicrosoft">
-                <span class="oauth-icon microsoft" aria-hidden="true"></span>
-                <span>Continue with Microsoft</span>
-              </button>
-              <button class="btn btn-oauth btn-apple" type="button" id="signupApple">
-                <span class="oauth-icon apple" aria-hidden="true"><i class="bi bi-apple"></i></span>
-                <span>Continue with Apple</span>
-              </button>
-            </div>
-
-            <p class="small text-secondary text-center mb-0">
-              After signing up, we’ll bring you back here to complete onboarding details.
-            </p>
-
-            <p class="small text-center text-secondary mt-3 mb-0">
-              By continuing you agree to our <a href="/legal.html#terms">Terms</a> and <a href="/legal.html#privacy">Privacy Policy</a>.
-            </p>
-
-            <div class="text-center mt-3">
-              <span class="text-secondary small">Already have an account?</span>
-              <a class="small ms-1" href="/login.html">Sign in</a>
-            </div>
-
-            <div class="text-center small text-secondary mt-2">
-              Invited by our team?
-              <a href="https://versatile-refuge-31.authkit.app/invite" target="_blank" rel="noopener">Open your invite link</a>.
-            </div>
-          </div>
-        </section>
-      </div>
+  <main>
+    <div class="redirect-card" role="status" aria-live="polite">
+      <h1>Create your account</h1>
+      <p id="redirect-status" class="text-secondary">We’ll open the secure WorkOS sign-up so you can join with email and magic link.</p>
+      <div id="redirect-error" class="alert alert-danger d-none" role="alert"></div>
+      <a id="redirect-link" class="btn btn-primary w-100" href="/api/auth/workos/start?intent=signup">Continue to WorkOS</a>
+      <p class="fallback">Already have an account? <a href="/api/auth/workos/login">Sign in with WorkOS</a>.</p>
     </div>
   </main>
 
-  <!-- Light footer to match login aesthetic -->
-  <footer class="site-footer py-4">
-    <div class="container d-flex flex-wrap gap-3 align-items-center justify-content-between">
-      <div class="small">&copy; <span id="y"></span> AI Accountant. All rights reserved.</div>
-      <div class="d-flex gap-3 small">
-        <a class="link-secondary" href="/">Home</a>
-        <a class="link-secondary" href="/login.html">Sign in</a>
-        <a class="link-secondary" href="/legal.html">Legal</a>
-      </div>
-    </div>
-  </footer>
-
-  <!-- Same script setup as your original -->
   <script src="./js/auth.js"></script>
   <script>
     Auth.enforce({ allowAnonymous: ['login.html','signup.html','index.html'], bounceIfAuthed: true });
   </script>
-  <script src="/js/mobile-sidebar.js"></script>
   <script src="./js/signup.js"></script>
-
-  <!-- Tiny UI-only helpers (purely aesthetic) -->
-  <script>
-    // Entrance reveal (visual only)
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach(e => { if(e.isIntersecting){ e.target.classList.add('in'); io.unobserve(e.target); } });
-    }, { threshold: 0.14 });
-    document.querySelectorAll('.reveal').forEach(el => io.observe(el));
-
-    // Year in footer
-    document.getElementById('y').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- add a reusable WorkOS URL builder and update auth helpers to redirect through hosted auth
- replace the login and signup pages with minimal redirect shims that rely on WorkOS email/magic link
- point public links and client-side fallbacks directly at the WorkOS routes while keeping error handling minimal

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e52482730c83219b77939ea45ed518