### PR TITLE
Fix trial subscription status persistence during onboarding

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -1019,7 +1019,7 @@ router.post('/onboarding/complete', auth, async (req, res) => {
           interval: planSelection.interval,
           price: planSelection.selection === 'trial' ? 0 : planPrice(resolvedTier, planSelection.interval),
           currency: 'GBP',
-          status: 'active',
+          status: subscriptionStatus,
           startedAt: now,
           currentPeriodEnd: renewsAt
         },


### PR DESCRIPTION
## Summary
- ensure onboarding subscription upsert uses the computed subscription status so trials are persisted correctly

## Testing
- not run (backend change)

------
https://chatgpt.com/codex/tasks/task_e_68e5e79dfbdc8321bfcbd4fafb9b40c0