### PR TITLE
Add rerun onboarding path from profile

### DIFF
--- a/frontend/js/profile.js
+++ b/frontend/js/profile.js
@@ -433,6 +433,17 @@
     });
   }
 
+  function bindOnboardingRerun() {
+    const btn = $('#btn-rerun-onboarding');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      if (state.user?.onboardingComplete) {
+        sessionStorage.setItem('onboarding_return_to', window.location.pathname);
+      }
+      window.location.href = '/onboarding.html?rerun=1';
+    });
+  }
+
   function initNotes() {
     const textarea = $('#notes-box');
     const saveBtn = $('#btn-notes-save');
@@ -511,6 +522,7 @@
       renderBilling();
       computeStats();
       bindProfileEditing();
+      bindOnboardingRerun();
       initNotes();
     } catch (err) {
       console.error('Profile initialisation failed', err);

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -378,6 +378,9 @@
           <div class="eyebrow">Account</div>
           <h1 class="page-title" data-page-title>Profile</h1>
         </div>
+        <div class="d-flex flex-wrap gap-2">
+          <button class="btn btn-outline-primary" id="btn-rerun-onboarding" type="button">Rerun onboarding</button>
+        </div>
       </div>
       <p class="hero-sub">See how Phloat is compounding value for you. These KPIs sync from the <a href="./scenario-lab.html">Scenario Lab</a>, <a href="./document-vault.html">Document Vault</a>, and <a href="./wealth-lab.html">Wealth Lab</a> so you can evidence savings, compliance readiness, and debt reduction from a single hub.</p>
       <div class="tile-grid" id="stat-tiles"></div>


### PR DESCRIPTION
## Summary
- add a rerun onboarding button on the profile page and wire it to the onboarding flow
- preload the onboarding wizard with existing survey answers, plan choices, and stored payment snapshots for returning users
- allow the onboarding completion endpoint to reuse saved payment details when rerunning so returning users can refresh their data

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e5e5703e208321b1b9b08bbd1af88c