### PR TITLE
Fix profile onboarding rerun syntax error

### DIFF
--- a/frontend/js/profile.js
+++ b/frontend/js/profile.js
@@ -164,7 +164,8 @@
     const emailMeta = state.user.emailVerified ? 'All secure' : 'Verify in settings';
 
     const usage = state.user.usageStats || {};
-    const saved = Number(usage.moneySavedCumulative ?? usage.moneySavedEstimate || 0);
+    const savedEstimate = usage.moneySavedEstimate || 0;
+    const saved = Number(usage.moneySavedCumulative ?? savedEstimate);
     const savedDelta = usage.moneySavedChangePct;
     const savedTone = savedDelta == null ? 'info' : savedDelta >= 0 ? 'up' : 'down';
     let savedMeta = '';


### PR DESCRIPTION
## Summary
- avoid mixing nullish coalescing with logical OR when computing saved money statistics
- restore execution of the profile script so the rerun onboarding button navigates correctly

## Testing
- node --check frontend/js/profile.js

------
https://chatgpt.com/codex/tasks/task_e_68e5fbc2024083219223bef8df97e7ec