### PR TITLE
Load core stylesheets directly in HTML heads

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -5,6 +5,11 @@
   <title>Page Not Found — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, nofollow">
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <link rel="preload" href="/css/styles.css" as="style">
   <link rel="stylesheet" href="/css/styles.css">

--- a/frontend/billing-checkout.html
+++ b/frontend/billing-checkout.html
@@ -1,6 +1,11 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
 </head>
 <body>

--- a/frontend/billing.html
+++ b/frontend/billing.html
@@ -1,6 +1,11 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
 </head>
 <body>

--- a/frontend/compensation.html
+++ b/frontend/compensation.html
@@ -1,6 +1,11 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <title>Compensation Navigator — Phloat.io</title>
 </head>

--- a/frontend/document-vault.html
+++ b/frontend/document-vault.html
@@ -7,6 +7,11 @@
 
   <!-- Shared theme, Bootstrap, Bootstrap Icons, helpers -->
   <script>window.__API_BASE = window.__API_BASE || 'https://ai-accountant-app.onrender.com';</script>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
 
   <style>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1,6 +1,11 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <title>Dashboard — AI Accountant</title>
 </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Theme + libs -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script>window.__API_BASE = window.__API_BASE || 'http://localhost:3000';</script>
   <script src="/js/head-include.js"></script>
 

--- a/frontend/js/head-include.js
+++ b/frontend/js/head-include.js
@@ -24,6 +24,12 @@
   }
 
   function loadStylesheetFast(href) {
+    const existingSheet = document.head.querySelector(`link[rel="stylesheet"][href="${href}"]`);
+    if (existingSheet) {
+      existingSheet.setAttribute('fetchpriority', existingSheet.getAttribute('fetchpriority') || 'high');
+      return;
+    }
+
     const supportsPreload = (() => {
       const link = document.createElement('link');
       return !!(link.relList && link.relList.supports && link.relList.supports('preload'));

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -5,6 +5,11 @@
   <title>Login — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>window.__API_BASE = window.__API_BASE || 'http://localhost:3000';</script>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <style>
     body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:var(--bg-body);color:var(--fg);margin:0;font-family:var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);}

--- a/frontend/onboarding.html
+++ b/frontend/onboarding.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Welcome to Phloat — Onboarding</title>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <style>
     body.onboarding-body {

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <title>Profile — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
 
   <style>

--- a/frontend/scenario-lab.html
+++ b/frontend/scenario-lab.html
@@ -5,6 +5,11 @@
   <title>Scenario Lab — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
 
   <style>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -5,6 +5,11 @@
   <title>Sign up — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script>window.__API_BASE = window.__API_BASE || 'http://localhost:3000';</script>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <style>
     body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:var(--bg-body);color:var(--fg);margin:0;font-family:var(--font-sans,'Inter',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif);}

--- a/frontend/tax-lab.html
+++ b/frontend/tax-lab.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Tax Lab — AI Accountant</title>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <style>
     :root {

--- a/frontend/unauthorized.html
+++ b/frontend/unauthorized.html
@@ -5,6 +5,11 @@
   <title>Unauthorized — AI Accountant</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, nofollow">
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <link rel="preload" href="/css/styles.css" as="style">
   <link rel="stylesheet" href="/css/styles.css">

--- a/frontend/wealth-lab.html
+++ b/frontend/wealth-lab.html
@@ -1,6 +1,11 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script src="/js/head-include.js"></script>
   <title>Wealth Strategy Lab — Phloat.io</title>
 </head>


### PR DESCRIPTION
## Summary
- inline Bootstrap, Bootstrap Icons, and the app stylesheet in every HTML document head
- fall back to the existing stylesheet when the dynamic loader runs so CSS isn’t requested twice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e603f296408321af138335b7a173b2