### PR TITLE
Fix document vault auth helper path

### DIFF
--- a/frontend/document-vault.html
+++ b/frontend/document-vault.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="/css/styles.css" fetchpriority="high">
   <script>window.__API_BASE = window.__API_BASE || '';</script>
   <script src="/js/head-include.js"></script>
-  <script src="/auth.js"></script>
+  <script src="/js/auth.js"></script>
   <style>
     :root {
       color-scheme: light dark;


### PR DESCRIPTION
## Summary
- update the document vault page to load the shared /js/auth.js helper so API requests include the bearer token

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e62b7c58ac8321874fbee7fccff484