### PR TITLE
fix: add missing s3 dependency to worker service

### DIFF
--- a/services/worker/package.json
+++ b/services/worker/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.9",
+    "@aws-sdk/client-s3": "^3.637.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "mongoose": "^8.5.1",


### PR DESCRIPTION
## Summary
- add the AWS S3 SDK dependency to the worker package so it can load the shared R2 helper

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e634495488832199645dfb70a11615