### PR TITLE
Add persistent vault upload progress tracking

### DIFF
--- a/frontend/document-vault.html
+++ b/frontend/document-vault.html
@@ -117,6 +117,56 @@
       margin: 0;
     }
 
+    .vault-progress {
+      margin-bottom: 24px;
+      padding: 12px 18px 20px;
+      border-radius: var(--vault-radius);
+      border: 1px solid rgba(103, 89, 255, 0.08);
+      background: rgba(103, 89, 255, 0.04);
+      box-shadow: var(--vault-shadow-soft);
+    }
+
+    .vault-progress[hidden] {
+      display: none !important;
+    }
+
+    .vault-progress__meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 12px;
+    }
+
+    .vault-progress__phase {
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .vault-progress__count {
+      font-size: 0.85rem;
+      color: var(--vault-muted);
+      white-space: nowrap;
+    }
+
+    .vault-progress__bar {
+      position: relative;
+      width: 100%;
+      height: 10px;
+      border-radius: 999px;
+      background: rgba(103, 89, 255, 0.18);
+      overflow: hidden;
+    }
+
+    .vault-progress__fill {
+      position: absolute;
+      inset: 0;
+      width: 0%;
+      border-radius: inherit;
+      background: var(--vault-accent);
+      transition: width 0.3s ease;
+    }
+
     .session-empty {
       color: var(--vault-muted);
       font-size: 0.9rem;
@@ -406,6 +456,16 @@
       <h1>Smart Document Vault</h1>
       <p class="lede">Upload payslips, statements, ISA and investment reports, pensions, and HMRC correspondence. We classify, extract, and surface insights automatically.</p>
     </header>
+
+    <section class="vault-progress" id="vault-progress" hidden aria-hidden="true">
+      <div class="vault-progress__meta">
+        <span class="vault-progress__phase" id="vault-progress-phase">Preparing uploads…</span>
+        <span class="vault-progress__count" id="vault-progress-count"></span>
+      </div>
+      <div class="vault-progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+        <div class="vault-progress__fill" id="vault-progress-bar"></div>
+      </div>
+    </section>
 
     <section class="upload-layout">
       <div class="card">


### PR DESCRIPTION
## Summary
- add a dedicated progress indicator to the vault page so users can see upload, extraction, and analytics phases with counts
- persist upload session data in local storage and restore it on load so queued files stay visible across visits
- surface placeholder progress while uploads are in-flight and update the session panel/pollers accordingly

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e682413b708321839111083ca5c17d